### PR TITLE
feat(deploy): GHCR publish workflow and standalone deploy files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/svagtlys/otaki-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      - name: Extract metadata for frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/svagtlys/otaki-frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/README.md
+++ b/README.md
@@ -33,22 +33,51 @@ Full details in [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ---
 
-## Setup
+## Deploy
 
-> **Prerequisites:** Docker + Docker Compose.
+> **Prerequisites:** Docker + Docker Compose, and a running [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) instance.
+
+Download the deployment files:
 
 ```bash
-export UID GID          # ensures ./data, ./library, ./suwayomi are owned by your user
+mkdir otaki && cd otaki
+curl -fsSL https://raw.githubusercontent.com/Svagtlys/Otaki/main/deploy/docker-compose.yml -o docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/Svagtlys/Otaki/main/deploy/nginx.conf -o nginx.conf
+mkdir -p data suwayomi library covers watermarks
+curl -fsSL https://raw.githubusercontent.com/Svagtlys/Otaki/main/deploy/.env.example -o data/.env
+```
+
+Edit `data/.env` — at minimum, set these two values:
+
+```bash
+SUWAYOMI_URL=http://<your-suwayomi-host>:4567
+SECRET_KEY=<output of: openssl rand -hex 32>
+```
+
+Start Otaki:
+
+```bash
+UID=$(id -u) GID=$(id -g) docker compose up -d
+```
+
+Open `http://localhost` — the setup wizard will guide you through source configuration on first run.
+
+The `mkdir -p` step above creates the host directories as your user before Docker mounts them — this ensures the backend process has write access. All path variables (`LIBRARY_PATH`, `SUWAYOMI_DOWNLOAD_PATH`, etc.) are pre-configured by `docker-compose.yml`.
+
+To update to a new version: edit the image tags in `docker-compose.yml`, then run `docker compose pull && docker compose up -d`.
+
+---
+
+## For Developers (local build)
+
+```bash
+git clone https://github.com/Svagtlys/Otaki.git && cd Otaki
 cp .env.example .env
 # Minimum required in .env:
 #   SECRET_KEY=<random string>
 #   SUWAYOMI_URL=http://suwayomi:4567   # if using the bundled suwayomi service
-docker compose -f docker/docker-compose.yml up
+UID=$(id -u) GID=$(id -g) docker compose -f docker/docker-compose.yml up
 ```
-
-Open `http://localhost` — the setup wizard will guide you through connecting Suwayomi and configuring source priority on first run.
-
-Host directories (`./data/`, `./library/`, `./suwayomi/`) are created automatically on first run. `LIBRARY_PATH` and `SUWAYOMI_DOWNLOAD_PATH` are pre-configured by docker-compose and do not need to be set in `.env`.
 
 ---
 
@@ -68,7 +97,7 @@ Available naming tokens: `{title}`, `{chapter}`, `{volume}`, `{year}`, `{source}
 
 ---
 
-## For Developers
+## Developer Docs
 
 - [docs/PLAN.md](docs/PLAN.md) — full design: data model, workflows, tech stack
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — file-by-file breakdown of every service and worker

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,43 @@
+# Otaki configuration — copy this file to ./data/.env and fill in your values.
+#
+# NOTE: LIBRARY_PATH, SUWAYOMI_DOWNLOAD_PATH, COVERS_PATH, WATERMARKS_PATH,
+# and DATABASE_URL are pre-configured by docker-compose.yml — do not set them here.
+
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# URL of your Suwayomi-Server instance (must be reachable from the Otaki container)
+# Example: http://192.168.1.10:4567
+SUWAYOMI_URL=
+
+# Secret key for JWT session signing — generate with: openssl rand -hex 32
+SECRET_KEY=
+
+
+# ── Suwayomi auth (only if your Suwayomi instance requires login) ─────────────
+
+# SUWAYOMI_USERNAME=
+# SUWAYOMI_PASSWORD=
+
+
+# ── Optional tuning (defaults shown) ─────────────────────────────────────────
+
+# How often to check for new chapters AND run source upgrade checks, in days.
+# DEFAULT_POLL_DAYS=7
+
+# Naming template for relocated chapter files.
+# Tokens: {title}, {chapter} (e.g. 12.5), {volume}, {year}, {source}
+# Example with zero-padded chapter: {title}/{title} - Ch.{chapter:06.1f}.cbz
+# CHAPTER_NAMING_FORMAT={title}/{title} - Ch.{chapter}.cbz
+
+# How Otaki moves settled chapters to the library:
+#   auto     — hardlink if source and library are on the same filesystem, copy otherwise
+#   hardlink — always hardlink (fails if filesystems differ)
+#   copy     — always copy (safe across filesystems, uses extra disk space until source is removed)
+#   move     — move the file directly; fastest when source and library are on the same filesystem,
+#              but if they are on different filesystems a crash mid-copy can leave the staging copy
+#              deleted and the library file incomplete. Prefer copy if unsure.
+# RELOCATION_STRATEGY=auto
+
+# How many times to re-enqueue a failed download before marking it permanently failed.
+# MAX_DOWNLOAD_RETRIES=2

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,46 @@
+# Otaki — standalone deployment
+#
+# Prerequisites:
+#   1. Docker + Docker Compose installed
+#   2. A running Suwayomi-Server instance (not included here)
+#
+# Quick start:
+#   1. Download this file and nginx.conf into the same directory
+#   2. Copy .env.example to ./data/.env and fill in the required values
+#   3. Run:  UID=$(id -u) GID=$(id -g) docker compose up -d
+#
+# To update: change the image tags below, then run:
+#   docker compose pull && docker compose up -d
+
+services:
+  backend:
+    # Update this tag when upgrading — https://github.com/Svagtlys/Otaki/releases
+    image: ghcr.io/svagtlys/otaki-backend:1.0.0
+    user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      ENV_FILE: "/app/data/.env"
+      DATABASE_URL: "sqlite+aiosqlite:////app/data/otaki.db"
+      LIBRARY_PATH: "/app/library"
+      SUWAYOMI_DOWNLOAD_PATH: "/app/suwayomi_data/downloads"
+      COVERS_PATH: "/app/covers"
+      WATERMARKS_PATH: "/app/watermarks"
+    volumes:
+      - ./data:/app/data
+      - ./suwayomi:/app/suwayomi_data
+      - ./library:/app/library
+      - ./covers:/app/covers
+      - ./watermarks:/app/watermarks
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+
+  frontend:
+    # Keep in sync with the backend tag above
+    image: ghcr.io/svagtlys/otaki-frontend:1.0.0
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:8080"
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 8080;
+    root /usr/share/nginx/html;
+
+    location /api {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Closes #64

## Summary

- **`.github/workflows/publish.yml`** — builds `otaki-backend` and `otaki-frontend` and pushes to GHCR on `v*.*.*` tags; multi-arch (amd64 + arm64), tagged semver + `latest`, uses `GITHUB_TOKEN` (no extra secrets)
- **`deploy/docker-compose.yml`** — standalone compose using pre-built GHCR images; all 5 volumes (`data`, `suwayomi`, `library`, `covers`, `watermarks`)
- **`deploy/nginx.conf`** — copy of `docker/nginx.conf` for standalone use
- **`deploy/.env.example`** — deployment env template; only `SUWAYOMI_URL` + `SECRET_KEY` required; full explanations for all optional settings
- **`README.md`** — `## Setup` → `## Deploy` (curl 3 files, mkdir, edit 2 vars, `docker compose up`); adds `## For Developers (local build)` section

## Test plan

- [ ] Push a `v1.0.0` tag to a fork — verify the workflow completes and both packages appear in GHCR
- [ ] Set packages public
- [ ] Fresh directory: run the `curl` commands from the README, fill in `data/.env`, run `UID=$(id -u) GID=$(id -g) docker compose up -d`
- [ ] Verify `http://localhost` loads the setup wizard
- [ ] Complete setup, run a search, verify a download request works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)