### PR TITLE
fix: ensure nginx static files are world-readable in frontend container

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,5 +6,17 @@ COPY . .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:alpine
+
+# Copy files and ensure they are world-readable (755 for dirs, 644 for files)
 COPY --from=build /app/dist /usr/share/nginx/html
+
+# Switch to root briefly to fix permissions for ANY future user
+USER root
+RUN chmod -R 755 /usr/share/nginx/html && \
+    chown -R root:root /usr/share/nginx/html
+    
+# Switch back to the default unprivileged user (uid 101)
+# The Compose file 'user:' directive will override this at runtime
+USER 101
+
 EXPOSE 8080


### PR DESCRIPTION
Closes #66

## What

After `COPY --from=build`, briefly switch to `root` to `chmod -R 755` and `chown -R root:root` the static assets, then drop back to uid 101 (the nginx unprivileged default). This ensures the files are world-readable regardless of what `user:` override is set in Compose at runtime.