### PR TITLE
fix(scheduler): catch up overdue polls and upgrades on startup, fix tuple unpacking and UTC consistency

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Backend Tests: Full Suite",
+      "detail": "Run all backend tests including integration (requires Suwayomi running)",
+      "type": "shell",
+      "command": "\"${workspaceFolder}/backend/.venv/bin/python\" -m pytest --no-header -v",
+      "workingDirectory": "${workspaceFolder}/backend",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend Tests: Unit Only (No Suwayomi)",
+      "detail": "Run only unit tests, skip integration tests",
+      "type": "shell",
+      "command": "\"${workspaceFolder}/backend/.venv/bin/python\" -m pytest --no-header -v -m 'not integration'",
+      "workingDirectory": "${workspaceFolder}/backend",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend Tests: Current File",
+      "detail": "Run tests for the currently open test file",
+      "type": "shell",
+      "command": "\"${workspaceFolder}/backend/.venv/bin/python\" -m pytest --no-header -v ${file}",
+      "workingDirectory": "${workspaceFolder}/backend",
+      "problemMatcher": [],
+      "when": "resourceLangId == python"
+    }
+  ],
+  "inputs": []
+}

--- a/backend/app/workers/scheduler.py
+++ b/backend/app/workers/scheduler.py
@@ -26,6 +26,8 @@ async def start(db: AsyncSession) -> None:
     for comic in comics:
         _register_poll_job(comic)
         _register_upgrade_job(comic)
+    # Process any missed poll or upgrade jobs that were scheduled while the service was down.
+    await _process_missed_jobs(db)
     if not scheduler.running:
         scheduler.start()
     _started_at = datetime.now(timezone.utc)
@@ -123,6 +125,7 @@ def _register_poll_job(comic: Comic) -> None:
         id=f"poll_{comic.id}",
         args=[comic.id],
         replace_existing=True,
+        misfire_grace_time=3600,
     )
 
 
@@ -206,7 +209,31 @@ def _register_upgrade_job(comic: Comic) -> None:
         id=f"upgrade_{comic.id}",
         args=[comic.id],
         replace_existing=True,
+        misfire_grace_time=3600,
     )
+
+# Process missed jobs on startup
+async def _process_missed_jobs(db: AsyncSession) -> None:
+    """Run any poll or upgrade jobs that are overdue.
+
+    This ensures that when Otaki starts after being down, it does not silently drop
+    missed executions. It simply invokes the corresponding coroutine for each
+    overdue job.
+    """
+    now = datetime.now(timezone.utc)
+    result = await db.execute(select(Comic).where(Comic.status == ComicStatus.tracking))
+    comics = result.scalars().all()
+    for comic in comics:
+        if (
+            comic.next_poll_at
+            and comic.next_poll_at.replace(tzinfo=timezone.utc) < now
+        ):
+            await _poll_comic(comic.id)
+        if (
+            comic.next_upgrade_check_at
+            and comic.next_upgrade_check_at.replace(tzinfo=timezone.utc) < now
+        ):
+            await _upgrade_comic(comic.id)
 
 
 async def _upgrade_comic(comic_id: int) -> None:

--- a/backend/app/workers/scheduler.py
+++ b/backend/app/workers/scheduler.py
@@ -114,7 +114,12 @@ def _register_poll_job(comic: Comic) -> None:
     scheduler.add_job(
         func=_poll_comic,
         trigger="date",
-        run_date=comic.next_poll_at or datetime.now(timezone.utc),
+        run_date=(
+            comic.next_poll_at.replace(tzinfo=timezone.utc)
+            if comic.next_poll_at
+            and comic.next_poll_at.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc)
+            else datetime.now(timezone.utc)
+        ),
         id=f"poll_{comic.id}",
         args=[comic.id],
         replace_existing=True,
@@ -192,7 +197,12 @@ def _register_upgrade_job(comic: Comic) -> None:
     scheduler.add_job(
         func=_upgrade_comic,
         trigger="date",
-        run_date=comic.next_upgrade_check_at or datetime.now(timezone.utc),
+        run_date=(
+            comic.next_upgrade_check_at.replace(tzinfo=timezone.utc)
+            if comic.next_upgrade_check_at
+            and comic.next_upgrade_check_at.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc)
+            else datetime.now(timezone.utc)
+        ),
         id=f"upgrade_{comic.id}",
         args=[comic.id],
         replace_existing=True,

--- a/backend/app/workers/scheduler.py
+++ b/backend/app/workers/scheduler.py
@@ -136,7 +136,7 @@ async def _poll_comic(comic_id: int) -> None:
             logger.info("_poll_comic: comic_id=%d status=complete — skipping", comic_id)
             return
 
-        chapter_map = await source_selector.build_chapter_source_map(comic, db)
+        chapter_map, source_errors = await source_selector.build_chapter_source_map(comic, db)
 
         existing_result = await db.execute(
             select(ChapterAssignment.chapter_number).where(

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -486,6 +486,43 @@ async def test_upgrade_falls_back_to_poll_override_days(sched_db, monkeypatch):
 # Integration test — requires live Suwayomi
 # ---------------------------------------------------------------------------
 
+def test_poll_job_has_misfire_grace_time(monkeypatch):
+    """_register_poll_job sets misfire_grace_time to 1 hour (3600 seconds)."""
+    # Use a dummy comic
+    comic = _make_comic()
+    comic.id = 123
+    # Capture job registration
+    captured = {}
+    def fake_add_job(*args, **kwargs):
+        captured.update(kwargs)
+    monkeypatch.setattr(scheduler_module.scheduler, "add_job", fake_add_job)
+    # Register
+    scheduler_module._register_poll_job(comic)
+    assert captured.get("id") == f"poll_{comic.id}"
+    assert captured.get("misfire_grace_time") == 3600
+
+@pytest.mark.asyncio
+async def test_start_processes_missed_poll(monkeypatch, sched_db):
+    """scheduler.start processes overdue poll jobs immediately."""
+    past = datetime.now(UTC) - timedelta(days=1)
+    async with sched_db() as db:
+        comic = _make_comic(next_poll_at=past)
+        db.add(comic)
+        await db.commit()
+        comic_id = comic.id
+    # Patch the poll function to record call
+    called = []
+    async def fake_poll(comic_id_inner):
+        called.append(comic_id_inner)
+    monkeypatch.setattr(scheduler_module, "_poll_comic", fake_poll)
+    # Patch add_job to avoid APScheduler side effects
+    monkeypatch.setattr(scheduler_module.scheduler, "add_job", lambda *a, **kw: None)
+    # Run start
+    async with sched_db() as db:
+        await scheduler_module.start(db)
+    assert comic_id in called
+
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,7 +426,8 @@ Each comic has two scheduled jobs (poll and upgrade). The interval for each is d
 Public API:
 
 - `start(db: AsyncSession) → None` — loads all comics with `status=tracking`, registers poll and upgrade jobs for each, then calls `scheduler.start()`. Called from `main.py` lifespan on startup.
-- `register_comic_jobs(comic: Comic) → None` — registers poll and upgrade jobs for a newly created comic. Called by `POST /api/requests` after committing the new `Comic` row.
+- `register_comic_jobs(comic: Comic) → None` — registers poll and upgrade jobs for a newly created comic. Jobs are created with a `misfire_grace_time` of 1 hour to ensure missed executions are caught. On application startup, any overdue poll or upgrade jobs are processed immediately via a catch‑up routine.
+
 - `remove_comic_jobs(comic_id: int) → None` — removes all APScheduler jobs for a comic (poll and upgrade). Called by `DELETE /api/requests/{id}`. `JobLookupError` is silently suppressed — safe to call even if jobs were never registered.
 
 Internal:

--- a/docs/superpowers/plans/2026-04-24-scheduler-misfire-grace-146.md
+++ b/docs/superpowers/plans/2026-04-24-scheduler-misfire-grace-146.md
@@ -1,0 +1,93 @@
+# Scheduler Misfire Grace Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure overdue polls are not silently dropped on startup by correctly handling APScheduler `misfire_grace_time` and adding catch‑up logic.
+
+**Architecture:** Adjust the scheduler startup to process any missed poll/upgrade jobs that occurred while the service was down. Add explicit `misfire_grace_time` configuration to jobs and safeguard against null `next_*_at` values.
+
+**Tech Stack:** Python 3.11, APScheduler, SQLAlchemy (Async), Otaki backend.
+
+---
+
+### Task 1: Add `misfire_grace_time` to job registration
+
+**Files:**
+- Modify: `backend/app/workers/scheduler.py` (lines where `scheduler.add_job` is called for poll and upgrade jobs)
+- Test: `backend/tests/workers/test_scheduler.py`
+
+- [ ] **Step 1: Write failing test**
+```python
+def test_poll_job_has_misfire_grace_time(monkeypatch):
+    # Setup scheduler in a fresh state
+    from otaki.workers import scheduler as sched_mod
+    sched_mod.scheduler.remove_all_jobs()
+    # Register a dummy poll job via internal helper
+    comic = DummyComic(id=1, next_poll_at=datetime.utcnow() - timedelta(hours=2))
+    sched_mod._register_poll_job(comic)
+    job = sched_mod.scheduler.get_job(f"poll_{comic.id}")
+    assert job.misfire_grace_time == 3600  # 1 hour expected
+```
+- [ ] **Step 2: Run test to verify it fails** (expect failure because `misfire_grace_time` not set)
+- [ ] **Step 3: Implement `misfire_grace_time` parameter** – update both `_register_poll_job` and `_register_upgrade_job` calls to include `misfire_grace_time=3600` (1 hour). Add comment explaining rationale.
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 2: Add catch‑up logic on startup
+
+**Files:**
+- Modify: `backend/app/workers/scheduler.py` – `start` function
+- Add helper: `_process_missed_jobs()` in same file
+- Test: `backend/tests/workers/test_scheduler_startup.py`
+
+- [ ] **Step 1: Write failing test**
+```python
+def test_start_processes_missed_poll(monkeypatch, async_session):
+    # Simulate a comic whose next_poll_at is in the past
+    comic = Comic(id=2, status=ComicStatus.tracking, next_poll_at=datetime.utcnow() - timedelta(days=1))
+    async_session.add(comic)
+    await async_session.commit()
+    # Patch _poll_comic to record invocation instead of real work
+    calls = []
+    async def fake_poll(comic_id):
+        calls.append(comic_id)
+    monkeypatch.setattr(sched_mod, "_poll_comic", fake_poll)
+    await sched_mod.start(async_session)
+    assert 2 in calls  # poll should have run immediately
+```
+- [ ] **Step 2: Run test to verify it fails** (no processing of missed jobs)
+- [ ] **Step 3: Implement `_process_missed_jobs`** – after loading comics, iterate over each comic, if `next_poll_at` or `next_upgrade_check_at` is in the past, immediately schedule the job with `run_date=datetime.now(timezone.utc)` and invoke the corresponding coroutine (`_poll_comic`/`_upgrade_comic`) via `asyncio.create_task` or `await` inside start loop.
+- [ ] **Step 4: Call `_process_missed_jobs`** right after registering jobs in `start` before `scheduler.start()`.
+- [ ] **Step 5: Run test to verify it passes**
+- [ ] **Step 6: Commit**
+
+### Task 3: Update documentation
+
+**Files:**
+- Edit: `docs/ARCHITECTURE.md` – section *Scheduler* to mention `misfire_grace_time` and startup catch‑up behavior.
+- Edit: `docs/API.md` – note that poll/upgrade endpoints may be triggered on startup if overdue.
+
+- [ ] **Step 1: Add documentation updates** (no test needed)
+- [ ] **Step 2: Commit**
+
+### Task 4: Verify overall integration
+
+**Files:**
+- Test: `backend/tests/integration/test_scheduler_integration.py`
+
+- [ ] **Step 1: Write integration test** ensuring that when the service restarts after a downtime, overdue polls are processed and no errors are logged.
+- [ ] **Step 2: Run test, expect failure**
+- [ ] **Step 3: Ensure logs contain info about missed job processing** (use `caplog`).
+- [ ] **Step 4: Run test, expect pass**
+- [ ] **Step 5: Commit**
+
+---
+
+**Execution Handoff**
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-24-scheduler-misfire-grace-146.md`. Two execution options:
+
+1. **Subagent‑Driven (recommended)** – dispatch a fresh subagent per task, review between tasks.
+2. **Inline Execution** – execute tasks sequentially in this session using `superpowers:executing-plans`.
+
+Which approach would you like to use?

--- a/skills/discover-ready-issues/SKILL.md
+++ b/skills/discover-ready-issues/SKILL.md
@@ -1,0 +1,118 @@
+---
+description: Discover ready‑state issues on the active GitHub milestone, summarize each issue, and rate them by priority and difficulty. Use when you need an overview of what work remains before a release.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+Identify all *ready* issues on the repository’s current active milestone, produce a short summary for each, and assign a priority & difficulty rating.
+
+## Steps
+
+### 1. Determine the active milestone
+
+```bash
+gh api repos/Svagtlys/Otaki/milestones --jq '.[] | select(.state=="open") | .title' | head -n1
+```
+
+- The command lists open milestones; the first one (chronologically newest) is considered the active milestone.
+- Store the title in a variable, e.g. `ACTIVE_MILESTONE`.
+- If no open milestone is found, **stop and tell the user**.
+
+### 2. List ready‑state issues for that milestone
+
+```bash
+gh issue list \
+  --milestone "$ACTIVE_MILESTONE" \
+  --state open \
+  --json number,title,labels,assignees,createdAt,updatedAt,comments
+```
+
+- The `ready` label is used to denote issues that are ready to be worked on. Adjust the label name if your project uses a different convention.
+- Save the JSON output to a variable (`ISSUES_JSON`) for processing.
+
+### 3. Summarize and rate each issue (script)
+
+Create a script (e.g. `discover_ready_issues.sh`) with the following content and make it executable (`chmod +x`). The script prints a markdown report to stdout.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1️⃣ Determine active milestone
+ACTIVE_MILESTONE=$(gh api repos/Svagtlys/Otaki/milestones --jq '.[] | select(.state=="open") | .title' | head -n1)
+if [[ -z "$ACTIVE_MILESTONE" ]]; then
+  echo "No open milestone found" >&2
+  exit 1
+fi
+
+# Header for the markdown report
+echo "# Issue Report – $ACTIVE_MILESTONE (generated $(date))"
+echo "| # | Title | Age | Assignee | Rating |"
+echo "|---|---|---|---|---|"
+
+# 2️⃣ Fetch issues JSON
+ISSUES_JSON=$(gh issue list \
+  --milestone "$ACTIVE_MILESTONE" \
+  --state open \
+  --json number,title,labels,assignees,createdAt,updatedAt,comments)
+
+# 3️⃣ Process with jq
+echo "$ISSUES_JSON" | jq -r '
+  # Keep only issues that have the "ready" label
+  [ .[] | select(.labels != null and (.labels | map(.name) | index("ready")) != null) ] |
+  map(
+    # Age in days
+    (now - (.createdAt | fromdate)) / 86400 | floor as $age |
+    # First assignee or "unassigned"
+    (if .assignees and (.assignees|length)>0 then .assignees[0].login else "unassigned" end) as $assignee |
+    # Priority heuristic from labels
+    (if (.labels|map(.name)|index("critical")) != null then "P1"
+     elif (.labels|map(.name)|index("high")) != null then "P2"
+     elif (.labels|map(.name)|index("medium")) != null then "P3"
+     else "P4" end) as $priority |
+    # Difficulty heuristic from comment count and a possible "blocked" label
+    (if (.comments|length) > 15 or (.labels|map(.name)|index("blocked")) != null then "D3"
+     elif (.comments|length) > 5 then "D2"
+     else "D1" end) as $difficulty |
+    "\($priority)/\($difficulty)" as $rating |
+    "| #\(.number) | \(.title) | \($age)d | \($assignee) | \($rating) |"
+  ) | .[]
+'
+```
+
+**Explanation of the `jq` pipeline**
+- Filters for issues with the `ready` label.
+- Calculates the age in days (`$age`).
+- Picks the first assignee (or `unassigned`).
+- Determines **priority** (`P1`‑`P4`) from `critical`, `high`, `medium` labels (default `P4`).
+- Determines **difficulty** (`D1`‑`D3`) from comment count and a possible `blocked` label.
+- Emits a markdown table row with the combined rating `P?/D?`.
+
+### 4. Run the script
+
+```bash
+./discover_ready_issues.sh > issue_report.md
+```
+The report will be printed to `issue_report.md`. You can copy it into release notes, a planning document, or a project board.
+
+### 5. Optional CSV export
+
+If you need a CSV for further analysis, replace the final `jq` block with a CSV output format, e.g.:
+
+```bash
+... | "\($priority)/\($difficulty),\(.number),\(.title),\($age),\($assignee)" ...
+```
+
+---
+
+**Notes**
+- The skill assumes the `gh` CLI is authenticated and has access to the Otaki repository.
+- Adjust label names (`ready`, `critical`, `high`, `medium`, `blocked`) to match your project’s conventions.
+- The heuristics for priority/difficulty are simple and can be refined.
+
+---
+
+**Usage example**
+```bash
+./discover_ready_issues.sh
+```
+The script will print the markdown report to stdout.

--- a/skills/finish-branch/SKILL.md
+++ b/skills/finish-branch/SKILL.md
@@ -1,0 +1,57 @@
+---
+description: Finish a feature branch for Otaki — verifies tests pass, checks docs are up to date, confirms commits with the user, then pushes and marks the PR ready for review. Use when implementation is complete.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+Finish a feature branch: verify tests and docs, confirm commits with the user, then push and mark the PR ready.
+
+## Steps
+
+### 1. Identify the PR and touched areas
+
+- Run `git diff develop...HEAD --name-only` to get all files changed on this branch
+- Run `gh pr list --head $(git branch --show-current) --json number,title,url` to find the open draft PR
+- If no PR is found, tell the user and stop
+
+### 2. Confirm tests pass
+
+- Identify which test areas are relevant based on the changed files (e.g. if `api/comics.py` changed, run comic API tests; if `services/source_selector.py` changed, run source selector tests)
+- Run the relevant existing tests and any new tests added on this branch
+- If any tests fail: **stop, report the failures, and do not proceed** until the user addresses them
+
+### 3. Confirm docs are up to date
+
+Check each of the following docs against the code changes on this branch. For each one, flag any gaps:
+
+- `docs/API.md` — does it reflect every new or changed endpoint?
+- `docs/ARCHITECTURE.md` — does it reflect every new or changed service/worker/method?
+- `docs/FLOWS.md` — do any flows need updating?
+- `CONTRIBUTING.md` — any process changes?
+
+If any doc is missing coverage for a code change, **do not proceed** — tell the user exactly what needs updating.
+
+### 4. Confirm commits with the user
+
+Show the user a summary of what will be committed:
+- Run `git status` and `git diff --stat`
+- List all unstaged/staged changes grouped by file
+- Propose commit(s) using the format `type(scope): description` per `CONTRIBUTING.md`
+  - If there are logical groupings (e.g. API changes separate from service changes, docs separate from code), propose multiple commits
+  - Always put doc updates in a separate commit from code changes
+
+**Wait for explicit user approval of the commit plan before making any commits.**
+
+### 5. Make commits and push
+
+After the user approves:
+- Stage and commit exactly as agreed
+- Push to the remote branch: `git push`
+- Confirm the push succeeded
+
+### 6. Mark PR as ready for review
+
+```bash
+gh pr ready
+```
+
+Show the user the PR URL and confirm it is now marked ready.

--- a/skills/merge-hotfix/SKILL.md
+++ b/skills/merge-hotfix/SKILL.md
@@ -1,0 +1,168 @@
+---
+description: Merge one or more hotfix branches into main, tag a patch release, push (fires GHCR publish), and backport to develop. Use when hotfix PRs are approved and ready to ship as a patch release.
+argument-hint: <version> (e.g. 1.0.1)
+---
+
+Merge approved hotfix PRs, tag a patch release, and backport fixes to develop.
+
+Patch version: $ARGUMENTS
+
+## Steps
+
+### 1. Resolve the version
+
+If $ARGUMENTS is empty, ask the user: "What patch version are you releasing? (e.g. 1.0.1)"
+
+Strip any leading `v` — work with bare semver. The git tag will be `v<version>`.
+
+### 2. List hotfix PRs ready to merge
+
+```bash
+gh pr list --base main --state open --json number,title,headRefName,reviewDecision,url
+```
+
+Show the list to the user. For each PR, note whether it is approved or still pending review.
+
+If any PRs are not yet approved, ask: "These PRs are not yet approved: [list]. Merge the approved ones now, or wait for all?" — **wait for the user's answer before continuing.**
+
+### 3. Verify main is clean and up to date
+
+```bash
+git fetch origin
+git checkout main
+git status
+git log origin/main..HEAD --oneline
+```
+
+- Confirm the working tree is clean
+- Confirm local main matches `origin/main`
+
+If either check fails, **stop and tell the user** — do not proceed.
+
+### 4. Determine the active release branch
+
+Check whether a `release/<major>.<minor>` branch exists for the version being patched:
+
+```bash
+git branch -r | grep "release/$(echo <version> | cut -d. -f1-2)"
+```
+
+- If it exists (e.g. `release/1.0`), hotfixes go to **both** `main` and `release/<major>.<minor>`.
+- If it does not exist, hotfixes go to `main` only (release branch will be cut when the minor version ships).
+
+### 5. Confirm the plan with the user
+
+Show the user exactly what will happen:
+
+```
+Hotfix release plan for v<version>:
+
+  PRs to merge into main (no squash):
+    - #<N> <title> (hotfix/<branch>)
+    ...
+
+  Also merge into release/<major>.<minor>:   ← only if branch exists
+    - same PRs (keeps release branch current for archival)
+
+  Then:
+    git tag v<version>
+    git push origin main
+    git push origin release/<major>.<minor>  ← only if branch exists
+    git push origin v<version>               ← fires the GHCR publish workflow
+
+  Backport each hotfix branch to develop:
+    git checkout develop
+    git merge --no-ff hotfix/<branch>   (repeated for each PR)
+    git push origin develop
+```
+
+**Wait for explicit user approval before running any git commands.**
+
+### 6. Merge each hotfix PR into main
+
+For each approved PR, merge it (no squash) directly via the branch:
+
+```bash
+git checkout main
+git merge --no-ff hotfix/<branch> -m "chore(hotfix): merge hotfix/<branch> into main"
+```
+
+If a merge has conflicts, **stop and tell the user** — do not attempt to resolve them automatically.
+
+After all merges:
+
+```bash
+git log --oneline -5
+```
+
+Show the user the resulting main commit history.
+
+### 7. Merge each hotfix PR into release/<major>.<minor> (if branch exists)
+
+```bash
+git checkout release/<major>.<minor>
+git pull origin release/<major>.<minor>
+```
+
+For each hotfix branch:
+
+```bash
+git merge --no-ff hotfix/<branch> -m "chore(hotfix): merge hotfix/<branch> into release/<major>.<minor>"
+```
+
+If a merge has conflicts, **stop and tell the user** — do not proceed.
+
+### 8. Tag and push
+
+```bash
+git tag v<version>
+git push origin main
+git push origin release/<major>.<minor>  # only if branch exists
+git push origin v<version>
+```
+
+Confirm the publish workflow fired:
+
+```bash
+gh run list --workflow publish.yml --limit 3
+```
+
+Show the user the Actions run URL.
+
+### 9. Backport each hotfix branch to develop
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+For each hotfix branch:
+
+```bash
+git merge --no-ff hotfix/<branch> -m "chore(hotfix): backport hotfix/<branch> to develop"
+```
+
+If a backport has conflicts, **stop and tell the user** — do not proceed with remaining backports until this is resolved.
+
+After all backports:
+
+```bash
+git push origin develop
+```
+
+### 10. Finish
+
+Report to the user:
+
+```
+✓ Hotfix PRs merged into main
+✓ Hotfix PRs merged into release/<major>.<minor>   ← only if branch existed
+✓ main tagged v<version>
+✓ GHCR publish workflow triggered
+✓ Hotfixes backported to develop
+
+Next steps:
+- Watch the workflow at: https://github.com/Svagtlys/Otaki/actions
+- Update deploy/docker-compose.yml image tags to v<version> if not already done
+- Close any related GitHub issues if not auto-closed by the merged PRs
+```

--- a/skills/release-otaki/SKILL.md
+++ b/skills/release-otaki/SKILL.md
@@ -1,0 +1,143 @@
+---
+description: Release Otaki — cuts a release/x.y branch from develop, merges to main (no squash), tags, pushes (fires GHCR publish workflow), and syncs back to develop. Use when all features for a release are merged into develop and you're ready to ship.
+argument-hint: <version> (e.g. 1.0.0)
+---
+
+Cut and publish an Otaki release following the branching strategy in `docs/CONTRIBUTING.md`.
+
+Version to release: $ARGUMENTS
+
+## Steps
+
+### 1. Resolve the version
+
+If $ARGUMENTS is empty, ask the user: "What version are you releasing? (e.g. 1.0.0)"
+
+Strip any leading `v` from the input — work with bare semver (e.g. `1.0.0`). The git tag will be `v1.0.0`.
+
+Determine the minor series (e.g. `1.0.0` → series `1.0`, `1.2.3` → series `1.2`). The release branch will be `release/1.0`.
+
+### 2. Verify develop is ready
+
+```bash
+git fetch origin
+git checkout develop
+git status
+git log origin/develop..HEAD --oneline
+```
+
+- Confirm the working tree is clean (no uncommitted changes)
+- Confirm the local develop is up to date with `origin/develop`
+- If either check fails, **stop and tell the user** — do not proceed
+
+List any open PRs targeting develop, so the user can confirm they're not waiting on anything:
+
+```bash
+gh pr list --base develop --state open
+```
+
+If there are open PRs, show them and ask the user: "These PRs are still open against develop. Proceed anyway?" — **wait for a yes before continuing.**
+
+### 3. Check the milestone for unfinished issues
+
+Look up the GitHub milestone matching the release version and list any issues that are not yet closed:
+
+```bash
+gh issue list --milestone "<version>" --state open
+```
+
+If `<version>` doesn't match a milestone name, try the minor series (e.g. `1.0` for version `1.0.0`) or list milestones to find the right one:
+
+```bash
+gh api repos/Svagtlys/Otaki/milestones --jq '.[] | {title, open_issues, closed_issues}'
+```
+
+If there are any open issues in the milestone, show them to the user and ask: "These issues are still open on the milestone. Are they deferred to a later release, or do they need to be completed first?" — **wait for a yes before continuing.**
+
+### 4. Check the ROADMAP for the release
+
+Read `docs/ROADMAP.md` and find the checklist for the version being released. Show the user which items are still marked `[ ]` (unchecked) and ask: "These roadmap items appear unchecked. Are they all actually complete, or are any genuinely unfinished?" — **wait for confirmation before continuing.**
+
+### 5. Confirm the plan with the user
+
+Show the user exactly what will happen:
+
+```
+Release plan for v<version>:
+
+  1. git checkout -b release/<series> origin/develop
+  2. git checkout main && git merge --no-ff --no-squash release/<series>
+  3. git tag v<version>
+  4. git push origin main
+  5. git push origin v<version>          ← fires the GHCR publish workflow
+  6. git checkout develop && git merge --no-ff --no-squash release/<series>
+  7. git push origin develop
+
+After step 5, the GitHub Actions workflow will build and push:
+  ghcr.io/svagtlys/otaki-backend:v<version>
+  ghcr.io/svagtlys/otaki-frontend:v<version>
+
+⚠  If this is the first release: after the workflow completes, manually set
+   both packages to public in GitHub → Packages settings.
+```
+
+**Wait for explicit user approval before running any git commands.**
+
+### 6. Cut the release branch
+
+```bash
+git checkout -b release/<series> origin/develop
+git push -u origin release/<series>
+```
+
+### 7. Merge into main (no squash)
+
+```bash
+git checkout main
+git pull origin main
+git merge --no-ff release/<series> -m "chore(release): merge release/<series> into main"
+```
+
+If there are merge conflicts, **stop and tell the user** — do not attempt to resolve them automatically.
+
+### 8. Tag and push
+
+```bash
+git tag v<version>
+git push origin main
+git push origin v<version>
+```
+
+Confirm the tag was pushed:
+
+```bash
+gh run list --workflow publish.yml --limit 3
+```
+
+Show the user the Actions run URL and tell them the workflow is running.
+
+### 9. Sync release branch back to develop (no squash)
+
+```bash
+git checkout develop
+git merge --no-ff release/<series> -m "chore(release): merge release/<series> back into develop"
+git push origin develop
+```
+
+### 10. Finish
+
+Report to the user:
+
+```
+✓ release/<series> cut from develop
+✓ main updated and tagged v<version>
+✓ GHCR publish workflow triggered
+✓ develop synced from release/<series>
+
+Next steps:
+- Watch the workflow at: https://github.com/Svagtlys/Otaki/actions
+- If this is the first release: set otaki-backend and otaki-frontend packages
+  to public at https://github.com/Svagtlys?tab=packages
+- Update the image tags in deploy/docker-compose.yml if they haven't been
+  updated yet (they should already match v<version>)
+```

--- a/skills/start-branch/SKILL.md
+++ b/skills/start-branch/SKILL.md
@@ -1,0 +1,70 @@
+---
+description: Start a new feature branch for Otaki issues — checks blockers, creates branch off develop, opens a draft PR, then plans the implementation. Use when beginning work on one or more GitHub issues.
+argument-hint: <issue-number(s)>
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+Start a new feature branch for one or more GitHub issues.
+
+Arguments: $ARGUMENTS
+
+## Steps
+
+### 1. Confirm issues are unblocked and ready
+
+For each issue number provided in $ARGUMENTS:
+- Fetch the issue from GitHub using `gh issue view <number>`
+- Check the issue's body and comments for any blockers (phrases like "blocked by", "depends on", "waiting on")
+- Confirm the issue is assigned to the **Otaki** milestone
+- Confirm the issue's project status is **Ready** (not In Progress, In Review, or Backlog)
+
+If any issue is blocked, not on the Otaki milestone, or not in Ready status: **stop and tell the user** — do not proceed until they confirm.
+
+### 2. Determine branch name
+
+- Read the issue title(s) and number(s)
+- Propose a branch name using the format: `feat/<short-description>` or `fix/<short-description>` based on the issue type
+- Use lowercase kebab-case, keep it under 40 chars
+- Tell the user the proposed branch name and ask them to confirm or change it before creating
+
+### 3. Create the branch off develop
+
+```bash
+git fetch origin
+git checkout -b <branch-name> origin/develop
+```
+
+### 4. Create an empty commit and open a draft PR
+
+Create an empty commit to start the branch:
+
+```bash
+git commit --allow-empty -m "chore: start branch for #<issue-number(s)>"
+git push -u origin <branch-name>
+```
+
+Then open a draft PR against `develop` that links to all issues:
+- Title: match the primary issue title
+- Body: closes each issue with `Closes #<number>` (one per line)
+- Use `gh pr create --draft --base develop`
+
+Show the user the PR URL when done.
+
+### 5. Enter planning mode
+
+After the PR is created, switch to plan mode to design the implementation.
+
+Before planning, read the relevant design docs:
+- `PLAN.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API.md`
+- `docs/FLOWS.md`
+
+Then produce a concrete implementation plan covering:
+- Files to create or modify
+- New endpoints, services, or worker logic
+- Database model changes (if any)
+- Tests required (integration tests for all new endpoints/services)
+- Doc updates needed (`docs/API.md`, `docs/ARCHITECTURE.md`, etc.)
+
+Present the plan and wait for the user to approve before any code is written.


### PR DESCRIPTION
## Summary

- **Fix**: Unpack `(chapter_map, source_errors)` from `build_chapter_source_map` correctly — previously the code treated a tuple as a dict causing AttributeError at startup
- **Fix**: Normalize all datetime comparisons to use UTC (`datetime.now(timezone.utc)`) rather than mixing naive and offset-aware datetimes across `_register_poll_job`, `_register_upgrade_job`, `_process_missed_jobs`, and `_upgrade_comic`
- **Fix**: Add `misfire_grace_time=3600` to both poll and upgrade job registrations so APScheduler doesn't silently drop jobs that miss their run time by less than 1 hour
- **Feature**: Add `_process_missed_jobs()` which runs overdue polls/upgrades immediately on startup, ensuring no missed chapters while Otaki was down (closes #146)

## Testing

- `test_poll_job_has_misfire_grace_time` — verifies misfire_grace_time is set
- `test_start_processes_missed_poll` — verifies catch-up polling works on startup

## Docs

Updated docs/ARCHITECTURE.md to reflect new scheduler behaviour.