### PR TITLE
fix: update scheduler test mocks + add agent docs

### DIFF
--- a/.roo/rules-architect/AGENTS.md
+++ b/.roo/rules-architect/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - Architect Mode Rules
+
+This file provides architectural guidance specific to this repository.
+
+## Critical Architecture Rules (Non-Obvious)
+
+- **Otaki drives ALL polling** - Suwayomi does not auto-discover chapters. APScheduler jobs call `suwayomi.fetch_chapters()` and decide what to download.
+- **`chapter_event_handler` does NOT drive upgrades or polls** - it only handles: scan → fix → relocate, and upgrade-swap decisions when downloads complete.
+- **Suwayomi is staging; `LIBRARY_PATH` is final library** - files move to library only when chapter is settled (scanned, fixed if needed).
+- **Atomic file replacement during upgrades** - uses `os.replace()` so the library file is never missing during source upgrades.
+- **Hardlinks preferred for relocation** - same filesystem uses `os.link()`, cross-filesystem uses copy + verify + replace pattern.
+- **Cadence inference filters hiatus gaps** - gaps > 3x median are excluded before computing final median from `chapter_published_at`.
+- **Per-comic source priority overrides** - `ComicSourceOverride` rows let specific comics treat sources differently than global ranking.

--- a/.roo/rules-ask/AGENTS.md
+++ b/.roo/rules-ask/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md - Ask Mode Rules
+
+This file provides documentation context specific to this repository.
+
+## Critical Documentation Context (Non-Obvious)
+
+- **`CLAUDE.md` is the primary design document** - contains non-obvious decisions, data model, roles, and key service responsibilities.
+- **`comic.title` vs `comic.library_title`** - `title` is UI display name, `library_title` is used for filesystem paths and ComicInfo.xml. They can differ.
+- **Suwayomi is a download engine only** - Otaki owns all orchestration, polling, source selection, and quality decisions. Suwayomi does not auto-discover chapters.
+- **Two independent scheduled jobs per comic** - poll job (new chapters) and upgrade job (better sources) with separate configurable intervals.
+- **Backend commands run from `backend/` directory** - all pytest, uvicorn, ruff, and alembic commands require `cd backend/` first.
+- **Frontend dev server proxies `/api` to `localhost:8000`** - configured in `vite.config.ts`.

--- a/.roo/rules-code/AGENTS.md
+++ b/.roo/rules-code/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md - Code Mode Rules
+
+This file provides coding guidance specific to this repository.
+
+## Running Backend Commands
+
+**ALL backend Python commands MUST use the virtual environment at `backend/.venv/`.** Prefix with `backend/.venv/bin/` (e.g., `backend/.venv/bin/pytest`, `backend/.venv/bin/uvicorn`, `backend/.venv/bin/ruff`). Do NOT use system Python or `python -m pytest`.
+
+## Critical Coding Rules (Non-Obvious)
+
+- **Always use `source_selector.effective_priority(source, comic, db)`** when comparing source priorities - never read `source.priority` directly in routing logic.
+- **Always use `comic.library_title`** (not `comic.title`) in `file_relocator` and `comicinfo_writer` services.
+- **Always use `chapter_published_at`** for time-based chapter calculations (not `downloaded_at`).
+- **Source selection is per-chapter** - each `ChapterAssignment` has its own `source_id`. Different chapters of the same comic can use different sources.
+- **Search results are NOT deduplicated** - duplicates are resolved via `ComicAlias` rows.
+- **Hardlinks preferred for file relocation** - use `os.link()` same filesystem, `shutil.copy2()` + `os.replace()` cross-filesystem.
+- **Settings loaded via `pydantic_settings.BaseSettings`** from `.env` - use `from app.config import settings` to access.
+- **Logger pattern**: `logger = logging.getLogger(f"otaki.{__name__}")` - all modules follow this naming convention.
+- **Test fixtures monkeypatch the scheduler** - `scheduler.start`, `scheduler.shutdown`, `scheduler.add_job` are no-ops in unit tests.
+- **Integration tests need `.env.test`** file with real Suwayomi credentials - marked with `@pytest.mark.integration`.

--- a/.roo/rules-debug/AGENTS.md
+++ b/.roo/rules-debug/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md - Debug Mode Rules
+
+This file provides debugging guidance specific to this repository.
+
+## Critical Debug Rules (Non-Obvious)
+
+- **Tests use in-memory SQLite** - the database is recreated per test via conftest fixtures. No persistent state between tests.
+- **HTTP client fixtures monkeypatch multiple settings** - `SETUP_COMPLETE`, `SUWAYOMI_*`, `LIBRARY_PATH` are overridden. Real values only in integration tests.
+- **Scheduler is disabled in unit test fixtures** - `scheduler.start/shutdown/add_job` are lambda no-ops. Real APScheduler only in integration tests.
+- **Integration tests require running Suwayomi instance** - marked `@pytest.mark.integration`, skip if `.env.test` missing `SUWAYOMI_URL`.
+- **Logging configured via dictConfig in `app/main.py`** - `otaki.*` loggers at INFO, `sqlalchemy.engine` at WARNING, `gql`/`httpx` silenced.
+- **Environment file path controlled by `ENV_FILE` env var** - defaults to `.env` relative to backend directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Project Overview
+
+Otaki is a manga/comic request manager built on top of Suwayomi-Server (used only as a download engine). Full design docs: [`CLAUDE.md`](CLAUDE.md), [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`docs/API.md`](docs/API.md).
+
+## Stack
+
+- **Backend**: Python 3.13, FastAPI, SQLAlchemy async, aiosqlite, APScheduler, Alembic
+- **Frontend**: React 18, TypeScript, Vite, Tailwind
+- **E2E Tests**: Playwright
+- **Package Manager**: pip (backend), npm (frontend)
+
+## Commands
+
+All commands must be run from the `backend/` or `frontend/` directory respectively.
+
+**IMPORTANT: Backend Python commands MUST use the virtual environment at `backend/.venv/`.** Always prefix with `backend/.venv/bin/` (e.g., `backend/.venv/bin/pytest`) or activate the venv first (e.g., `source backend/.venv/bin/activate`).
+
+| Action | Command | Dir |
+|--------|---------|-----|
+| Run server | `backend/.venv/bin/uvicorn app.main:app --reload` | backend/ |
+| Run all tests | `backend/.venv/bin/pytest` | backend/ |
+| Run single test | `backend/.venv/bin/pytest tests/test_file.py::test_name -v` | backend/ |
+| Run integration tests | `backend/.venv/bin/pytest -m integration` | backend/ |
+| Lint Python | `backend/.venv/bin/ruff check .` | backend/ |
+| Fix lint | `backend/.venv/bin/ruff check . --fix` | backend/ |
+| DB migrations | `backend/.venv/bin/alembic upgrade head` | backend/ |
+| Frontend dev | `npm run dev` | frontend/ |
+| Frontend build | `npm run build` | frontend/ |
+| E2E tests | `npx playwright test` | frontend/ |
+
+## Critical Non-Obvious Rules (from CLAUDE.md)
+
+- **Source selection is per-chapter** - each `ChapterAssignment` has its own `source_id`. Different chapters of the same comic can come from different sources.
+- **Always use `source_selector.effective_priority(source, comic, db)`** - never read `source.priority` directly.
+- **Always use `comic.library_title`** (not `comic.title`) in `file_relocator` and `comicinfo_writer`.
+- **Always use `chapter_published_at`** for time-based chapter calculations (not `downloaded_at`).
+- **Cadence inferred from `chapter_published_at`** with hiatus filtering (>3x median gaps excluded).
+- **Two scheduled jobs per comic**: poll (new chapters) and upgrade (better sources) - independent intervals.
+- **Search results are NOT deduplicated** - user picks duplicates via `ComicAlias` rows.
+- **Suwayomi is staging**; `LIBRARY_PATH` is final library. Hardlinks preferred for relocation.
+- **Do NOT mock Suwayomi client in integration tests** - use real running instance.
+
+## Testing
+
+- Tests use in-memory SQLite via [`backend/tests/conftest.py`](backend/tests/conftest.py) fixtures
+- Integration tests require `.env.test` with real Suwayomi credentials (marked `@pytest.mark.integration`)
+- Fixtures: `db_session` (bare DB), `client` (HTTP), `auth_client` (setup complete), `logged_in_client` (JWT)
+- Scheduler is monkeypatched in HTTP test fixtures - real scheduler only in integration tests

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -145,12 +145,21 @@ async def test_poll_no_new_chapters(sched_db, monkeypatch):
     fake_source.id = source_id
 
     async def fake_build_map(comic, db):
-        return {1.0: (fake_source, "manga-1", {
-            "chapter_number": 1.0,
-            "volume_number": None,
-            "suwayomi_chapter_id": "ch-1",
-            "chapter_published_at": datetime(2024, 1, 1, tzinfo=UTC),
-        })}
+        return (
+            {
+                1.0: (
+                    fake_source,
+                    "manga-1",
+                    {
+                        "chapter_number": 1.0,
+                        "volume_number": None,
+                        "suwayomi_chapter_id": "ch-1",
+                        "chapter_published_at": datetime(2024, 1, 1, tzinfo=UTC),
+                    },
+                )
+            },
+            [],
+        )
 
     mock_enqueue = AsyncMock()
     monkeypatch.setattr(
@@ -185,12 +194,21 @@ async def test_poll_creates_assignments(sched_db, monkeypatch):
     fake_source.id = source_id
 
     async def fake_build_map(comic, db):
-        return {2.0: (fake_source, "manga-1", {
-            "chapter_number": 2.0,
-            "volume_number": None,
-            "suwayomi_chapter_id": "ch-2",
-            "chapter_published_at": published,
-        })}
+        return (
+            {
+                2.0: (
+                    fake_source,
+                    "manga-1",
+                    {
+                        "chapter_number": 2.0,
+                        "volume_number": None,
+                        "suwayomi_chapter_id": "ch-2",
+                        "chapter_published_at": published,
+                    },
+                )
+            },
+            [],
+        )
 
     mock_enqueue = AsyncMock()
     monkeypatch.setattr(
@@ -230,7 +248,7 @@ async def test_poll_advances_next_poll_at(sched_db, monkeypatch):
     monkeypatch.setattr(scheduler_module.scheduler, "add_job", MagicMock())
 
     async def fake_build_map(comic, db):
-        return {}
+        return {}, []
 
     monkeypatch.setattr(
         scheduler_module.source_selector, "build_chapter_source_map", fake_build_map
@@ -381,17 +399,21 @@ async def test_upgrade_creates_assignment_and_enqueues(sched_db, monkeypatch):
     monkeypatch.setattr(
         scheduler_module.source_selector,
         "find_upgrade_candidates",
-        AsyncMock(return_value=[(
-            fake_assignment,
-            fake_source_b,
-            "manga-99",
-            {
-                "chapter_number": 1.0,
-                "volume_number": None,
-                "suwayomi_chapter_id": "ch-upgrade-1",
-                "chapter_published_at": published,
-            },
-        )]),
+        AsyncMock(
+            return_value=[
+                (
+                    fake_assignment,
+                    fake_source_b,
+                    "manga-99",
+                    {
+                        "chapter_number": 1.0,
+                        "volume_number": None,
+                        "suwayomi_chapter_id": "ch-upgrade-1",
+                        "chapter_published_at": published,
+                    },
+                )
+            ]
+        ),
     )
     mock_enqueue = AsyncMock()
     monkeypatch.setattr(scheduler_module.suwayomi, "enqueue_downloads", mock_enqueue)
@@ -486,6 +508,7 @@ async def test_upgrade_falls_back_to_poll_override_days(sched_db, monkeypatch):
 # Integration test — requires live Suwayomi
 # ---------------------------------------------------------------------------
 
+
 def test_poll_job_has_misfire_grace_time(monkeypatch):
     """_register_poll_job sets misfire_grace_time to 1 hour (3600 seconds)."""
     # Use a dummy comic
@@ -493,13 +516,16 @@ def test_poll_job_has_misfire_grace_time(monkeypatch):
     comic.id = 123
     # Capture job registration
     captured = {}
+
     def fake_add_job(*args, **kwargs):
         captured.update(kwargs)
+
     monkeypatch.setattr(scheduler_module.scheduler, "add_job", fake_add_job)
     # Register
     scheduler_module._register_poll_job(comic)
     assert captured.get("id") == f"poll_{comic.id}"
     assert captured.get("misfire_grace_time") == 3600
+
 
 @pytest.mark.asyncio
 async def test_start_processes_missed_poll(monkeypatch, sched_db):
@@ -512,8 +538,10 @@ async def test_start_processes_missed_poll(monkeypatch, sched_db):
         comic_id = comic.id
     # Patch the poll function to record call
     called = []
+
     async def fake_poll(comic_id_inner):
         called.append(comic_id_inner)
+
     monkeypatch.setattr(scheduler_module, "_poll_comic", fake_poll)
     # Patch add_job to avoid APScheduler side effects
     monkeypatch.setattr(scheduler_module.scheduler, "add_job", lambda *a, **kw: None)
@@ -523,10 +551,11 @@ async def test_start_processes_missed_poll(monkeypatch, sched_db):
     assert comic_id in called
 
 
-
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_upgrade_comic_integration(sched_db, suwayomi_settings, test_manga_title, monkeypatch):
+async def test_upgrade_comic_integration(
+    sched_db, suwayomi_settings, test_manga_title, monkeypatch
+):
     """_upgrade_comic creates inactive upgrade assignments when a better-priority source has the chapter.
 
     Requires at least two Suwayomi sources that both return results for TEST_MANGA_TITLE.
@@ -536,16 +565,22 @@ async def test_upgrade_comic_integration(sched_db, suwayomi_settings, test_manga
 
     # Find two sources that both have the manga
     all_sources = await suwayomi_module.list_sources()
-    sources_with_manga: list[tuple[dict, str, str]] = []  # (source_info, manga_id, title)
+    sources_with_manga: list[
+        tuple[dict, str, str]
+    ] = []  # (source_info, manga_id, title)
     for src in all_sources:
         results = await suwayomi_module.search_source(src["id"], test_manga_title)
         if results:
-            sources_with_manga.append((src, results[0]["manga_id"], results[0]["title"]))
+            sources_with_manga.append(
+                (src, results[0]["manga_id"], results[0]["title"])
+            )
         if len(sources_with_manga) == 2:
             break
 
     if len(sources_with_manga) < 2:
-        pytest.skip("Need at least 2 sources that have the test manga for upgrade integration test")
+        pytest.skip(
+            "Need at least 2 sources that have the test manga for upgrade integration test"
+        )
 
     (src_a_info, manga_id_a, title_a), (src_b_info, manga_id_b, _) = sources_with_manga
 


### PR DESCRIPTION
- Fix test_poll_no_new_chapters, test_poll_creates_assignments, and test_poll_advances_next_poll_at: build_chapter_source_map() now returns tuple[dict, list] but mocks returned only a dict, causing ValueError on unpack at scheduler.py:142.

- Add AGENTS.md and .roo/ agent documentation files.