### PR TITLE
fix(file_relocator): Check for alias folders in file relocator

### DIFF
--- a/.roo/skills/finish-work-item/SKILL.md
+++ b/.roo/skills/finish-work-item/SKILL.md
@@ -87,28 +87,6 @@ Cross-reference each plan task with commits:
 | Task has no commits | Ask user — was this task skipped or forgotten? |
 | Uncommitted changes exist | Stage and commit with proper conventional commit message |
 | Commits not in plan | Verify they are related (refinements, fixes) — if unrelated, ask user |
-| WIP/fixup commits | Squash into parent commits using `git rebase -i` |
-
-### Clean Up WIP Commits
-
-If the branch has WIP, fixup, or empty commits, clean them up:
-
-```bash
-git rebase -i origin/develop
-```
-
-- Squash `fixup!` and `amend!` commits into their parents
-- Squash `WIP` commits into the nearest meaningful commit
-- Remove empty commits
-- Ensure each remaining commit has a proper conventional commit message
-
-**Important:** If the branch has already been pushed and others may have it checked out, merge `develop` instead of rebasing:
-
-```bash
-git fetch origin
-git merge origin/develop
-# resolve conflicts, commit
-```
 
 ### Ensure Proper Commit Messages
 
@@ -218,7 +196,6 @@ finish-work-item (code mode)  ← YOU ARE HERE
     ├── Step 3: Verify frontend build (if applicable)
     ├── Step 4: Load implementation plan
     ├── Step 5: Audit commits against plan
-    │   ├── Clean WIP/fixup commits
     │   └── Ensure conventional commit messages
     ├── Step 6: Stage remaining uncommitted work
     ├── Step 7: Push to origin

--- a/.roo/skills/plan-work-item/SKILL.md
+++ b/.roo/skills/plan-work-item/SKILL.md
@@ -63,7 +63,7 @@ The writing-plans skill will:
 
 ## Step 4: Direct to Implementation
 
-Once the plan is approved, inform the user that planning is complete. Provide a copy-able prompt for the user to pass to the code mode with the `/executing-plans` skill, which should include:
+Once the plan is approved, inform the user that planning is complete. Provide a copy-able prompt for the user to pass to the code mode with the `executing-plans` skill, which should start with `/executing-plans` and include:
 
 - The branch name
 - The draft PR URL

--- a/.roo/skills/start-work-item/SKILL.md
+++ b/.roo/skills/start-work-item/SKILL.md
@@ -116,7 +116,7 @@ GitHub automation will move the issue to **In Progress** when the draft PR is cr
 
 ## Step 6: Inform the User
 
-Once the branch is created and the draft PR is open, inform the user that the work item setup is complete. Provide a copy-able prompt for the user to pass to the architect mode with the `/plan-work-item` skill, which should include:
+Once the branch is created and the draft PR is open, inform the user that the work item setup is complete. Provide a copy-able prompt for the user to pass to the architect mode with the `plan-work-item` skill, which should start with `/plan-work-item` and include:
 
 - The branch name
 - The draft PR URL

--- a/backend/app/api/requests.py
+++ b/backend/app/api/requests.py
@@ -689,7 +689,11 @@ async def reprocess_chapters(
     """
 
     async def generate():
-        comic_result = await db.execute(select(Comic).where(Comic.id == comic_id))
+        comic_result = await db.execute(
+            select(Comic)
+            .where(Comic.id == comic_id)
+            .options(selectinload(Comic.aliases))
+        )
         comic = comic_result.scalar_one_or_none()
         if comic is None:
             yield f"data: {json.dumps({'type': 'error', 'detail': 'Comic not found'})}\n\n"
@@ -746,10 +750,7 @@ async def reprocess_chapters(
                 DownloadStatus.downloading,
             ):
                 staging = file_relocator.find_staging_path(
-                    chapter_name,
-                    manga_title,
-                    source_display_name,
-                    assignment.chapter_number,
+                    assignment, comic, chapter_name, source_display_name
                 )
                 if staging is not None:
                     # File already downloaded — treat as done and relocate (same as Case 4)
@@ -770,7 +771,6 @@ async def reprocess_chapters(
                             comic,
                             db,
                             chapter_name=chapter_name,
-                            manga_title=manga_title,
                             source_display_name=source_display_name,
                         )
                     else:
@@ -780,7 +780,6 @@ async def reprocess_chapters(
                             comic,
                             db,
                             chapter_name=chapter_name,
-                            manga_title=manga_title,
                             source_display_name=source_display_name,
                         )
                     processed += 1
@@ -829,10 +828,7 @@ async def reprocess_chapters(
             # Case 4: download done — check staging then library
             if assignment.download_status == DownloadStatus.done:
                 staging = file_relocator.find_staging_path(
-                    chapter_name,
-                    manga_title,
-                    source_display_name,
-                    assignment.chapter_number,
+                    assignment, comic, chapter_name, source_display_name
                 )
                 if staging is not None:
                     # Staging file exists — run the normal relocation pipeline
@@ -851,7 +847,6 @@ async def reprocess_chapters(
                             comic,
                             db,
                             chapter_name=chapter_name,
-                            manga_title=manga_title,
                             source_display_name=source_display_name,
                         )
                     else:
@@ -861,7 +856,6 @@ async def reprocess_chapters(
                             comic,
                             db,
                             chapter_name=chapter_name,
-                            manga_title=manga_title,
                             source_display_name=source_display_name,
                         )
                     processed += 1

--- a/backend/app/api/requests.py
+++ b/backend/app/api/requests.py
@@ -750,7 +750,7 @@ async def reprocess_chapters(
                 DownloadStatus.downloading,
             ):
                 staging = file_relocator.find_staging_path(
-                    assignment, comic, chapter_name, source_display_name
+                    assignment, comic, source_display_name
                 )
                 if staging is not None:
                     # File already downloaded — treat as done and relocate (same as Case 4)
@@ -770,7 +770,6 @@ async def reprocess_chapters(
                             assignment,
                             comic,
                             db,
-                            chapter_name=chapter_name,
                             source_display_name=source_display_name,
                         )
                     else:
@@ -779,7 +778,6 @@ async def reprocess_chapters(
                             assignment,
                             comic,
                             db,
-                            chapter_name=chapter_name,
                             source_display_name=source_display_name,
                         )
                     processed += 1
@@ -828,7 +826,7 @@ async def reprocess_chapters(
             # Case 4: download done — check staging then library
             if assignment.download_status == DownloadStatus.done:
                 staging = file_relocator.find_staging_path(
-                    assignment, comic, chapter_name, source_display_name
+                    assignment, comic, source_display_name
                 )
                 if staging is not None:
                     # Staging file exists — run the normal relocation pipeline
@@ -846,7 +844,6 @@ async def reprocess_chapters(
                             assignment,
                             comic,
                             db,
-                            chapter_name=chapter_name,
                             source_display_name=source_display_name,
                         )
                     else:
@@ -855,7 +852,6 @@ async def reprocess_chapters(
                             assignment,
                             comic,
                             db,
-                            chapter_name=chapter_name,
                             source_display_name=source_display_name,
                         )
                     processed += 1

--- a/backend/app/services/file_relocator.py
+++ b/backend/app/services/file_relocator.py
@@ -141,19 +141,58 @@ def _match_by_regex(
     return matches
 
 
+def _build_manga_titles(comic: Comic) -> list[str]:
+    """Build ordered list of folder names to search: primary title + aliases."""
+    titles = [comic.title]
+    for alias in comic.aliases:
+        titles.append(alias.title)
+    return titles
+
+
 def find_staging_path(
-    chapter_name: str, manga_title: str, source_display_name: str, chapter_number: float
+    assignment: ChapterAssignment,
+    comic: Comic,
+    chapter_name: str,
+    source_display_name: str,
 ) -> Path | None:
-    if not manga_title or manga_title == "":
+    """Find a chapter's staging file by searching through title and alias folders.
+
+    Derives manga titles from the Comic (primary title + aliases) and chapter
+    number from the ChapterAssignment. Tries each title folder in order and
+    returns the first successful match.
+    """
+    manga_titles = _build_manga_titles(comic)
+    chapter_number = assignment.chapter_number
+
+    if not manga_titles:
         return None
+
+    for manga_title in manga_titles:
+        if manga_title == "":
+            continue
+        result = _find_staging_path_for_title(
+            chapter_name, manga_title, source_display_name, chapter_number
+        )
+        if result is not None:
+            return result
+
+    return None
+
+
+def _find_staging_path_for_title(
+    chapter_name: str,
+    manga_title: str,
+    source_display_name: str,
+    chapter_number: float,
+) -> Path | None:
+    """Search for a chapter file under a single manga title directory.
+
+    This is the internal search logic that runs for each title in the alias list.
+    """
     source_dir = Path(settings.SUWAYOMI_DOWNLOAD_PATH) / source_display_name
     base = _find_manga_subdir(source_dir, manga_title)
 
     if base is None:
-        # Fuzzy fallback: scan SUWAYOMI_DOWNLOAD_PATH for a source directory whose
-        # normalised name starts with the normalised display name. This handles cases
-        # like displayName="Weeb Central" but on-disk dir="WeebCentral" or
-        # "Weeb Central (EN)". Also handles sanitized manga subdirectory names.
         download_root = Path(settings.SUWAYOMI_DOWNLOAD_PATH)
         norm_display = _normalize_source_name(source_display_name)
         candidates = [
@@ -165,23 +204,25 @@ def find_staging_path(
         ]
         if len(candidates) == 1:
             logger.warning(
-                "file_relocator: source dir %r not found; using fuzzy match %r for display name %r",
+                "file_relocator: source dir %r not found; using fuzzy match %r for display name %r (title %r)",
                 source_display_name,
                 candidates[0].name,
                 source_display_name,
+                manga_title,
             )
             base = _find_manga_subdir(candidates[0], manga_title)
         elif len(candidates) > 1:
             logger.warning(
                 "file_relocator: ambiguous source directory for display name %r — "
-                "multiple fuzzy matches: %s",
+                "multiple fuzzy matches: %s (title %r)",
                 source_display_name,
                 [d.name for d in candidates],
+                manga_title,
             )
             return None
 
     if base is None:
-        base = source_dir / manga_title  # non-existent path; triggers warning at end
+        base = source_dir / manga_title
 
     # --- 1. Exact CBZ match ---
     exact = base / f"{chapter_name}.cbz"
@@ -214,9 +255,10 @@ def find_staging_path(
         return subdirs[0]
 
     logger.warning(
-        "file_relocator: ambiguous or missing staging file for chapter %r in %s",
+        "file_relocator: ambiguous or missing staging file for chapter %r in %s (title %r)",
         chapter_name,
         base,
+        manga_title,
     )
     return None
 
@@ -350,7 +392,6 @@ async def relocate(
     comic: Comic,
     db: AsyncSession,
     chapter_name: str,
-    manga_title: str,
     source_display_name: str,
 ) -> None:
     await asyncio.to_thread(
@@ -359,7 +400,6 @@ async def relocate(
         comic,
         db,
         chapter_name,
-        manga_title,
         source_display_name,
     )
 
@@ -369,22 +409,19 @@ def _relocate_sync(
     comic: Comic,
     db: AsyncSession,
     chapter_name: str,
-    manga_title: str,
     source_display_name: str,
 ) -> None:
     logger.info(
         "relocate: starting for comic=%r chapter=%r source=%r",
-        manga_title,
+        comic.title,
         chapter_name,
         source_display_name,
     )
-    staging = find_staging_path(
-        chapter_name, manga_title, source_display_name, assignment.chapter_number
-    )
+    staging = find_staging_path(assignment, comic, chapter_name, source_display_name)
     if staging is None:
         logger.warning(
             "relocate: no staging file found for comic=%r chapter=%r source=%r — marking failed",
-            manga_title,
+            comic.title,
             chapter_name,
             source_display_name,
         )
@@ -406,7 +443,7 @@ def _relocate_sync(
     assignment.library_path = str(dest)
     assignment.relocation_status = RelocationStatus.done
     logger.info(
-        "relocate: done for comic=%r chapter=%r -> %s", manga_title, chapter_name, dest
+        "relocate: done for comic=%r chapter=%r -> %s", comic.title, chapter_name, dest
     )
 
 
@@ -416,7 +453,6 @@ async def replace_in_library(
     comic: Comic,
     db: AsyncSession,
     chapter_name: str,
-    manga_title: str,
     source_display_name: str,
 ) -> None:
     await asyncio.to_thread(
@@ -426,7 +462,6 @@ async def replace_in_library(
         comic,
         db,
         chapter_name,
-        manga_title,
         source_display_name,
     )
 
@@ -437,22 +472,19 @@ def _replace_in_library_sync(
     comic: Comic,
     db: AsyncSession,
     chapter_name: str,
-    manga_title: str,
     source_display_name: str,
 ) -> None:
     logger.info(
         "replace_in_library: starting upgrade for comic=%r chapter=%r source=%r",
-        manga_title,
+        comic.title,
         chapter_name,
         source_display_name,
     )
-    staging = find_staging_path(
-        chapter_name, manga_title, source_display_name, new.chapter_number
-    )
+    staging = find_staging_path(new, comic, chapter_name, source_display_name)
     if staging is None:
         logger.warning(
             "replace_in_library: no staging file found for comic=%r chapter=%r source=%r — marking failed",
-            manga_title,
+            comic.title,
             chapter_name,
             source_display_name,
         )

--- a/backend/app/services/file_relocator.py
+++ b/backend/app/services/file_relocator.py
@@ -152,17 +152,17 @@ def _build_manga_titles(comic: Comic) -> list[str]:
 def find_staging_path(
     assignment: ChapterAssignment,
     comic: Comic,
-    chapter_name: str,
     source_display_name: str,
 ) -> Path | None:
     """Find a chapter's staging file by searching through title and alias folders.
 
-    Derives manga titles from the Comic (primary title + aliases) and chapter
-    number from the ChapterAssignment. Tries each title folder in order and
-    returns the first successful match.
+    Derives manga titles from the Comic (primary title + aliases), chapter number
+    and chapter name from the ChapterAssignment. Tries each title folder in order
+    and returns the first successful match.
     """
     manga_titles = _build_manga_titles(comic)
     chapter_number = assignment.chapter_number
+    chapter_name = assignment.source_chapter_name or f"Chapter {chapter_number}"
 
     if not manga_titles:
         return None
@@ -391,7 +391,6 @@ async def relocate(
     assignment: ChapterAssignment,
     comic: Comic,
     db: AsyncSession,
-    chapter_name: str,
     source_display_name: str,
 ) -> None:
     await asyncio.to_thread(
@@ -399,7 +398,6 @@ async def relocate(
         assignment,
         comic,
         db,
-        chapter_name,
         source_display_name,
     )
 
@@ -408,16 +406,18 @@ def _relocate_sync(
     assignment: ChapterAssignment,
     comic: Comic,
     db: AsyncSession,
-    chapter_name: str,
     source_display_name: str,
 ) -> None:
+    chapter_name = (
+        assignment.source_chapter_name or f"Chapter {assignment.chapter_number}"
+    )
     logger.info(
         "relocate: starting for comic=%r chapter=%r source=%r",
         comic.title,
         chapter_name,
         source_display_name,
     )
-    staging = find_staging_path(assignment, comic, chapter_name, source_display_name)
+    staging = find_staging_path(assignment, comic, source_display_name)
     if staging is None:
         logger.warning(
             "relocate: no staging file found for comic=%r chapter=%r source=%r — marking failed",
@@ -452,7 +452,6 @@ async def replace_in_library(
     new: ChapterAssignment,
     comic: Comic,
     db: AsyncSession,
-    chapter_name: str,
     source_display_name: str,
 ) -> None:
     await asyncio.to_thread(
@@ -461,7 +460,6 @@ async def replace_in_library(
         new,
         comic,
         db,
-        chapter_name,
         source_display_name,
     )
 
@@ -471,16 +469,16 @@ def _replace_in_library_sync(
     new: ChapterAssignment,
     comic: Comic,
     db: AsyncSession,
-    chapter_name: str,
     source_display_name: str,
 ) -> None:
+    chapter_name = new.source_chapter_name or f"Chapter {new.chapter_number}"
     logger.info(
         "replace_in_library: starting upgrade for comic=%r chapter=%r source=%r",
         comic.title,
         chapter_name,
         source_display_name,
     )
-    staging = find_staging_path(new, comic, chapter_name, source_display_name)
+    staging = find_staging_path(new, comic, source_display_name)
     if staging is None:
         logger.warning(
             "replace_in_library: no staging file found for comic=%r chapter=%r source=%r — marking failed",

--- a/backend/app/workers/chapter_event_handler.py
+++ b/backend/app/workers/chapter_event_handler.py
@@ -95,7 +95,6 @@ async def handle(
                     assignment,
                     comic,
                     db,
-                    chapter_name=chapter_name,
                     source_display_name=source_display_name,
                 )
                 assignment.is_active = True
@@ -129,7 +128,6 @@ async def handle(
                         assignment,
                         comic,
                         db,
-                        chapter_name=chapter_name,
                         source_display_name=source_display_name,
                     )
                     existing_active.is_active = False

--- a/backend/app/workers/chapter_event_handler.py
+++ b/backend/app/workers/chapter_event_handler.py
@@ -68,7 +68,12 @@ async def handle(
         assignment.download_status = DownloadStatus.done
         assignment.downloaded_at = datetime.now(UTC)
 
-        comic = await db.get(Comic, assignment.comic_id)
+        comic = await db.execute(
+            select(Comic)
+            .where(Comic.id == assignment.comic_id)
+            .options(selectinload(Comic.aliases))
+        )
+        comic = comic.scalar_one()
 
         # Check whether this is an upgrade download (an active assignment already
         # exists for the same comic + chapter from a prior, lower-priority source).
@@ -91,7 +96,6 @@ async def handle(
                     comic,
                     db,
                     chapter_name=chapter_name,
-                    manga_title=manga_title,
                     source_display_name=source_display_name,
                 )
                 assignment.is_active = True
@@ -126,7 +130,6 @@ async def handle(
                         comic,
                         db,
                         chapter_name=chapter_name,
-                        manga_title=manga_title,
                         source_display_name=source_display_name,
                     )
                     existing_active.is_active = False

--- a/backend/tests/test_file_relocator.py
+++ b/backend/tests/test_file_relocator.py
@@ -17,9 +17,14 @@ from app.services import file_relocator
 # ---------------------------------------------------------------------------
 
 
-def _make_comic(title="My Comic", library_title="My Comic Library", cover_path=None):
+def _make_comic(
+    title="My Comic", library_title="My Comic Library", cover_path=None, aliases=None
+):
     return SimpleNamespace(
-        title=title, library_title=library_title, cover_path=cover_path
+        title=title,
+        library_title=library_title,
+        cover_path=cover_path,
+        aliases=aliases or [],
     )
 
 
@@ -157,13 +162,13 @@ async def test_relocate_calls_to_thread(tmp_path, monkeypatch):
     staging_file = source_dir / f"{chapter_name}.cbz"
     _make_cbz(staging_file)
 
-    comic = _make_comic(library_title="OnePiece")
+    comic = _make_comic(title="OnePiece", library_title="OnePiece")
     assignment = _make_assignment(chapter_number=1.0)
 
     with patch("asyncio.to_thread") as mock_to_thread:
         mock_to_thread.return_value = None
         await file_relocator.relocate(
-            assignment, comic, None, chapter_name, manga_title, source_display
+            assignment, comic, None, chapter_name, source_display
         )
         assert mock_to_thread.called
         assert mock_to_thread.call_args[0][0] == file_relocator._relocate_sync
@@ -192,12 +197,12 @@ async def test_relocate_hardlink(tmp_path, monkeypatch):
     staging_file = source_dir / f"{chapter_name}.cbz"
     _make_cbz(staging_file)
 
-    comic = _make_comic(library_title="OnePiece")
+    comic = _make_comic(title="OnePiece", library_title="OnePiece")
     assignment = _make_assignment(chapter_number=1.0)
 
     with patch("app.services.file_relocator.os.link", wraps=os.link) as mock_link:
         await file_relocator.relocate(
-            assignment, comic, None, chapter_name, manga_title, source_display
+            assignment, comic, None, chapter_name, source_display
         )
         assert mock_link.called  # hardlink path taken
 
@@ -231,7 +236,7 @@ async def test_relocate_cross_filesystem(tmp_path, monkeypatch):
     staging_file = source_dir / f"{chapter_name}.cbz"
     _make_cbz(staging_file)
 
-    comic = _make_comic(library_title="Bleach")
+    comic = _make_comic(title="Bleach", library_title="Bleach")
     assignment = _make_assignment(chapter_number=1.0)
 
     # Simulate cross-filesystem by making os.link raise OSError
@@ -240,7 +245,7 @@ async def test_relocate_cross_filesystem(tmp_path, monkeypatch):
         side_effect=OSError("cross-device link not permitted"),
     ):
         await file_relocator.relocate(
-            assignment, comic, None, chapter_name, manga_title, source_display
+            assignment, comic, None, chapter_name, source_display
         )
 
     assert assignment.relocation_status == RelocationStatus.done
@@ -264,13 +269,11 @@ async def test_relocate_staging_not_found(tmp_path, monkeypatch):
         settings, "CHAPTER_NAMING_FORMAT", "{title}/{title} - Ch.{chapter}.cbz"
     )
 
-    comic = _make_comic(library_title="Fairy Tail")
+    comic = _make_comic(title="Fairy Tail", library_title="Fairy Tail")
     assignment = _make_assignment(chapter_number=3.0)
 
     # No staging file created
-    await file_relocator.relocate(
-        assignment, comic, None, "Chapter 003", "FairyTail", "SomeSource"
-    )
+    await file_relocator.relocate(assignment, comic, None, "Chapter 003", "SomeSource")
 
     assert assignment.relocation_status == RelocationStatus.failed
     assert assignment.library_path is None
@@ -301,12 +304,10 @@ async def test_relocate_creates_parent_dirs(tmp_path, monkeypatch):
     staging_file = source_dir / f"{chapter_name}.cbz"
     _make_cbz(staging_file)
 
-    comic = _make_comic(library_title="DragonBall")
+    comic = _make_comic(title="DragonBall", library_title="DragonBall")
     assignment = _make_assignment(chapter_number=1.0)
 
-    await file_relocator.relocate(
-        assignment, comic, None, chapter_name, manga_title, source_display
-    )
+    await file_relocator.relocate(assignment, comic, None, chapter_name, source_display)
 
     assert assignment.relocation_status == RelocationStatus.done
     dest = Path(assignment.library_path)
@@ -336,12 +337,10 @@ async def test_relocate_with_folder_staging(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "CHAPTER_NAMING_FORMAT", "{title}/{chapter}")
     monkeypatch.setattr(settings, "RELOCATION_STRATEGY", "copy")
 
-    comic = _make_comic(library_title="My Manga")
+    comic = _make_comic(title="My Manga", library_title="My Manga")
     assignment = _make_assignment(chapter_number=1.0, volume_number=None)
 
-    await file_relocator.relocate(
-        assignment, comic, None, chapter_name, manga_title, source_display
-    )
+    await file_relocator.relocate(assignment, comic, None, chapter_name, source_display)
 
     assert assignment.relocation_status == RelocationStatus.done
 
@@ -391,7 +390,7 @@ async def test_replace_in_library_calls_to_thread(tmp_path, monkeypatch):
     existing_lib.parent.mkdir(parents=True)
     existing_lib.write_bytes(b"old content")
 
-    comic = _make_comic(library_title="HxH")
+    comic = _make_comic(title="HxH", library_title="HxH")
     old_assignment = _make_assignment(
         chapter_number=1.0, library_path=str(existing_lib)
     )
@@ -406,7 +405,6 @@ async def test_replace_in_library_calls_to_thread(tmp_path, monkeypatch):
             comic,
             None,
             chapter_name,
-            manga_title,
             source_display,
         )
         assert mock_to_thread.called
@@ -438,7 +436,7 @@ async def test_replace_in_library_atomic(tmp_path, monkeypatch):
     existing_lib.parent.mkdir(parents=True)
     existing_lib.write_bytes(b"old content")
 
-    comic = _make_comic(library_title="HxH")
+    comic = _make_comic(title="HxH", library_title="HxH")
     old_assignment = _make_assignment(
         chapter_number=1.0, library_path=str(existing_lib)
     )
@@ -451,7 +449,6 @@ async def test_replace_in_library_atomic(tmp_path, monkeypatch):
         comic,
         None,
         chapter_name,
-        manga_title,
         source_display,
     )
 
@@ -490,10 +487,9 @@ async def test_relocate_strategy_copy_keeps_staging(tmp_path, monkeypatch):
     assignment = _make_assignment(chapter_number=1.0)
     await file_relocator.relocate(
         assignment,
-        _make_comic(library_title="TestManga"),
+        _make_comic(title="TestManga", library_title="TestManga"),
         None,
         chapter_name,
-        manga_title,
         source_display,
     )
 
@@ -531,10 +527,9 @@ async def test_relocate_strategy_move_deletes_staging(tmp_path, monkeypatch):
     assignment = _make_assignment(chapter_number=1.0)
     await file_relocator.relocate(
         assignment,
-        _make_comic(library_title="TestManga"),
+        _make_comic(title="TestManga", library_title="TestManga"),
         None,
         chapter_name,
-        manga_title,
         source_display,
     )
 
@@ -576,10 +571,9 @@ async def test_replace_in_library_copy_strategy_keeps_staging(tmp_path, monkeypa
     await file_relocator.replace_in_library(
         old_assignment,
         new_assignment,
-        _make_comic(),
+        _make_comic(title="TestManga", library_title="TestManga"),
         None,
         chapter_name,
-        manga_title,
         source_display,
     )
 
@@ -605,7 +599,7 @@ async def test_replace_in_library_staging_not_found(tmp_path, monkeypatch):
     existing_lib.parent.mkdir(parents=True)
     existing_lib.write_bytes(b"original")
 
-    comic = _make_comic(library_title="SomeComic")
+    comic = _make_comic(title="SomeComic", library_title="SomeComic")
     old_assignment = _make_assignment(
         chapter_number=1.0, library_path=str(existing_lib)
     )
@@ -618,7 +612,6 @@ async def test_replace_in_library_staging_not_found(tmp_path, monkeypatch):
         comic,
         None,
         "Chapter 001",
-        "SomeComic",
         "NoSource",
     )
 
@@ -667,11 +660,11 @@ async def test_relocate_real_staging_file(path_config, monkeypatch):
     )
     monkeypatch.setattr(settings, "RELOCATION_STRATEGY", "copy")  # preserve staging
 
-    comic = _make_comic(library_title=manga_title)
+    comic = _make_comic(title=manga_title, library_title=manga_title)
     assignment = _make_assignment(chapter_number=1.0, source_name=source_display_name)
 
     await file_relocator.relocate(
-        assignment, comic, None, chapter_name, manga_title, source_display_name
+        assignment, comic, None, chapter_name, source_display_name
     )
 
     assert assignment.relocation_status == RelocationStatus.done
@@ -703,8 +696,10 @@ def test_find_staging_path_returns_folder(tmp_path, monkeypatch):
 
     monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, source_display, 1.0
+        assignment, comic, chapter_name, source_display
     )
 
     assert result == chapter_folder
@@ -833,7 +828,9 @@ async def test_relocate_injects_cover(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "CHAPTER_NAMING_FORMAT", "{title}/{chapter}")
     monkeypatch.setattr(settings, "RELOCATION_STRATEGY", "copy")
 
-    comic = _make_comic(library_title=manga_title, cover_path=str(cover_file))
+    comic = _make_comic(
+        title=manga_title, library_title=manga_title, cover_path=str(cover_file)
+    )
     assignment = _make_assignment(chapter_number=1.0, source_name=source_display)
 
     await file_relocator.relocate(
@@ -841,7 +838,6 @@ async def test_relocate_injects_cover(tmp_path, monkeypatch):
         comic,
         None,
         chapter_name=chapter_name,
-        manga_title=manga_title,
         source_display_name=source_display,
     )
 
@@ -1000,8 +996,10 @@ def test_find_staging_path_source_dir_space_stripped(tmp_path, monkeypatch):
     cbz = source_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "Weeb Central", 1.0
+        assignment, comic, chapter_name, "Weeb Central"
     )
     assert result == cbz
 
@@ -1019,8 +1017,10 @@ def test_find_staging_path_source_dir_with_suffix(tmp_path, monkeypatch):
     cbz = source_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "Weeb Central", 1.0
+        assignment, comic, chapter_name, "Weeb Central"
     )
     assert result == cbz
 
@@ -1037,8 +1037,10 @@ def test_find_staging_path_source_dir_case_mismatch(tmp_path, monkeypatch):
     cbz = source_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "weebcentral", 1.0
+        assignment, comic, chapter_name, "weebcentral"
     )
     assert result == cbz
 
@@ -1058,8 +1060,10 @@ def test_find_staging_path_source_dir_ambiguous_returns_none(tmp_path, monkeypat
         d.mkdir(parents=True)
         _make_cbz(d / f"{chapter_name}.cbz")
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "Weeb Central", 1.0
+        assignment, comic, chapter_name, "Weeb Central"
     )
     assert result is None
 
@@ -1082,8 +1086,10 @@ def test_find_staging_path_exact_match_skips_fallback(tmp_path, monkeypatch):
     fuzzy_dir.mkdir(parents=True)
     _make_cbz(fuzzy_dir / f"{chapter_name}.cbz")
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "ExactSource", 1.0
+        assignment, comic, chapter_name, "ExactSource"
     )
     assert result == cbz
 
@@ -1106,8 +1112,10 @@ def test_find_staging_path_sanitized_colon_in_title(tmp_path, monkeypatch):
     cbz = sanitized_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "SomeSource", 1.0
+        assignment, comic, chapter_name, "SomeSource"
     )
     assert result == cbz
 
@@ -1124,8 +1132,10 @@ def test_find_staging_path_sanitized_multiple_special_chars(tmp_path, monkeypatc
     cbz = sanitized_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "SomeSource", 1.0
+        assignment, comic, chapter_name, "SomeSource"
     )
     assert result == cbz
 
@@ -1143,8 +1153,10 @@ def test_find_staging_path_sanitized_ambiguous(tmp_path, monkeypatch):
         d.mkdir(parents=True)
         _make_cbz(d / f"{chapter_name}.cbz")
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "SomeSource", 1.0
+        assignment, comic, chapter_name, "SomeSource"
     )
     assert result is None
 
@@ -1162,8 +1174,10 @@ def test_find_staging_path_sanitized_in_fuzzy_source_dir(tmp_path, monkeypatch):
     cbz = sanitized_dir / f"{chapter_name}.cbz"
     _make_cbz(cbz)
 
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
     result = file_relocator.find_staging_path(
-        chapter_name, manga_title, "Weeb Central", 1.0
+        assignment, comic, chapter_name, "Weeb Central"
     )
     assert result == cbz
 
@@ -1181,7 +1195,11 @@ def test_find_staging_path_empty_manga_title_returns_none(tmp_path, monkeypatch)
     cbz_in_source_dir = downloads / source_display / f"{chapter_name}.cbz"
     _make_cbz(cbz_in_source_dir)
 
-    result = file_relocator.find_staging_path(chapter_name, "", source_display, 1.0)
+    comic = _make_comic(title="")
+    assignment = _make_assignment(chapter_number=1.0)
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
 
     assert result is None
 
@@ -1310,7 +1328,10 @@ class TestFindStagingPathRegex:
         )
 
         result = file_relocator.find_staging_path(
-            "Unknown Name", "My Manga", "TestSource", 5.0
+            _make_assignment(chapter_number=5.0),
+            _make_comic(title="My Manga"),
+            "Unknown Name",
+            "TestSource",
         )
         assert result == manga_dir / "MangaSee_Ch. 5.cbz"
 
@@ -1333,7 +1354,10 @@ class TestFindStagingPathRegex:
         )
 
         result = file_relocator.find_staging_path(
-            "Unknown Name", "My Manga", "TestSource", 10.0
+            _make_assignment(chapter_number=10.0),
+            _make_comic(title="My Manga"),
+            "Unknown Name",
+            "TestSource",
         )
         assert result == manga_dir / "Chapter 10"
 
@@ -1355,7 +1379,10 @@ class TestFindStagingPathRegex:
         )
 
         result = file_relocator.find_staging_path(
-            "Episode 5", "My Manga", "TestSource", 5.0
+            _make_assignment(chapter_number=5.0),
+            _make_comic(title="My Manga"),
+            "Episode 5",
+            "TestSource",
         )
         assert result == exact_cbz
 
@@ -1376,7 +1403,10 @@ class TestFindStagingPathRegex:
         )
 
         result = file_relocator.find_staging_path(
-            "Unknown", "My Manga", "TestSource", 5.0
+            _make_assignment(chapter_number=5.0),
+            _make_comic(title="My Manga"),
+            "Unknown",
+            "TestSource",
         )
         assert result == cbz
 
@@ -1398,9 +1428,156 @@ class TestFindStagingPathRegex:
 
         # Without regex config, and no exact match, should return None
         result = file_relocator.find_staging_path(
-            "Episode 148", "My Manga", "TestSource", 148.0
+            _make_assignment(chapter_number=148.0),
+            _make_comic(title="My Manga"),
+            "Episode 148",
+            "TestSource",
         )
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Alias folder search tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_staging_path_found_in_alias_folder(tmp_path, monkeypatch):
+    """Chapter file exists in alias folder, not primary title folder."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    # Primary title folder exists but has no chapter file
+    (downloads / source_display / "My Comic").mkdir(parents=True)
+
+    # Alias folder has the chapter file
+    alias_dir = downloads / source_display / "My Comic Alt"
+    alias_dir.mkdir(parents=True)
+    cbz = alias_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
+
+
+def test_find_staging_path_primary_title_takes_priority(tmp_path, monkeypatch):
+    """When both primary and alias folders have the file, primary wins."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    primary_dir = downloads / source_display / "My Comic"
+    primary_dir.mkdir(parents=True)
+    primary_cbz = primary_dir / f"{chapter_name}.cbz"
+    _make_cbz(primary_cbz)
+
+    alias_dir = downloads / source_display / "My Comic Alt"
+    alias_dir.mkdir(parents=True)
+    alias_cbz = alias_dir / f"{chapter_name}.cbz"
+    _make_cbz(alias_cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == primary_cbz
+
+
+def test_find_staging_path_not_found_in_any_title(tmp_path, monkeypatch):
+    """Chapter file missing from all title folders returns None."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    for title in ["My Comic", "My Comic Alt"]:
+        d = downloads / source_display / title
+        d.mkdir(parents=True)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result is None
+
+
+def test_find_staging_path_no_aliases_searches_only_primary(tmp_path, monkeypatch):
+    """Comic with no aliases searches only the primary title folder."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(title="My Comic", library_title="My Comic Library", aliases=[])
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    manga_dir = downloads / source_display / "My Comic"
+    manga_dir.mkdir(parents=True)
+    cbz = manga_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
+
+
+def test_find_staging_path_skips_to_second_alias(tmp_path, monkeypatch):
+    """File is in the second alias folder, skipping the first."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="Primary",
+        library_title="Primary Library",
+        aliases=[
+            SimpleNamespace(title="Alias One"),
+            SimpleNamespace(title="Alias Two"),
+        ],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    (downloads / source_display / "Primary").mkdir(parents=True)
+    (downloads / source_display / "Alias One").mkdir(parents=True)
+    alias2_dir = downloads / source_display / "Alias Two"
+    alias2_dir.mkdir(parents=True)
+    cbz = alias2_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
 
     def test_prefix_fallback_removed_for_folder(self, tmp_path, monkeypatch):
         """Old prefix-based folder fallback no longer exists."""

--- a/docs/superpowers/plans/2026-06-23-alias-folders-file-relocator.md
+++ b/docs/superpowers/plans/2026-06-23-alias-folders-file-relocator.md
@@ -1,0 +1,697 @@
+# Alias Folders File Relocator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `find_staging_path()` to search alias-named folders in Suwayomi staging, and fix undefined `manga_title` in `requests.py` reprocess endpoint.
+
+**Architecture:** Refactor `find_staging_path()` to accept `Comic` and `ChapterAssignment` domain objects instead of individual primitive parameters. The function derives manga titles (primary + aliases) from the `Comic` object and chapter number from the `ChapterAssignment`. This makes the API resilient to future model changes. `source_display_name` remains a parameter since it comes from the Suwayomi API. `chapter_name` remains a parameter since it may come from Suwayomi events.
+
+**Tech Stack:** Python 3.13, pytest, FastAPI, SQLAlchemy async
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `backend/app/services/file_relocator.py` | Core change: `find_staging_path()` accepts Comic + ChapterAssignment; `relocate()` / `replace_in_library()` derive manga_titles from Comic |
+| `backend/app/workers/chapter_event_handler.py` | Load Comic with aliases eagerly, pass to file_relocator |
+| `backend/app/api/requests.py` | Fix undefined `manga_title`, load Comic with aliases, pass to file_relocator |
+| `backend/tests/test_file_relocator.py` | Update tests to pass Comic/Assignment objects; add alias-search tests |
+
+---
+
+### Task 1: Add `_build_manga_titles` helper and refactor `find_staging_path()`
+
+**Files:**
+- Modify: `backend/app/services/file_relocator.py:144-221`
+- Test: `backend/tests/test_file_relocator.py`
+
+- [ ] **Step 1: Write failing tests for alias folder search**
+
+Add these tests to `backend/tests/test_file_relocator.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Alias folder search tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_staging_path_found_in_alias_folder(tmp_path, monkeypatch):
+    """Chapter file exists in alias folder, not primary title folder."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    # Primary title folder exists but has no chapter file
+    (downloads / source_display / "My Comic").mkdir(parents=True)
+
+    # Alias folder has the chapter file
+    alias_dir = downloads / source_display / "My Comic Alt"
+    alias_dir.mkdir(parents=True)
+    cbz = alias_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
+
+
+def test_find_staging_path_primary_title_takes_priority(tmp_path, monkeypatch):
+    """When both primary and alias folders have the file, primary wins."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    primary_dir = downloads / source_display / "My Comic"
+    primary_dir.mkdir(parents=True)
+    primary_cbz = primary_dir / f"{chapter_name}.cbz"
+    _make_cbz(primary_cbz)
+
+    alias_dir = downloads / source_display / "My Comic Alt"
+    alias_dir.mkdir(parents=True)
+    alias_cbz = alias_dir / f"{chapter_name}.cbz"
+    _make_cbz(alias_cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == primary_cbz
+
+
+def test_find_staging_path_not_found_in_any_title(tmp_path, monkeypatch):
+    """Chapter file missing from all title folders returns None."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="My Comic",
+        library_title="My Comic Library",
+        aliases=[SimpleNamespace(title="My Comic Alt")],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    for title in ["My Comic", "My Comic Alt"]:
+        d = downloads / source_display / title
+        d.mkdir(parents=True)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result is None
+
+
+def test_find_staging_path_no_aliases_searches_only_primary(tmp_path, monkeypatch):
+    """Comic with no aliases searches only the primary title folder."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(title="My Comic", library_title="My Comic Library", aliases=[])
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    manga_dir = downloads / source_display / "My Comic"
+    manga_dir.mkdir(parents=True)
+    cbz = manga_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
+
+
+def test_find_staging_path_skips_to_second_alias(tmp_path, monkeypatch):
+    """File is in the second alias folder, skipping the first."""
+    downloads = tmp_path / "downloads"
+    monkeypatch.setattr(settings, "SUWAYOMI_DOWNLOAD_PATH", str(downloads))
+
+    comic = _make_comic(
+        title="Primary",
+        library_title="Primary Library",
+        aliases=[
+            SimpleNamespace(title="Alias One"),
+            SimpleNamespace(title="Alias Two"),
+        ],
+    )
+    assignment = _make_assignment(chapter_number=1.0)
+    chapter_name = "Chapter 1"
+    source_display = "TestSource"
+
+    (downloads / source_display / "Primary").mkdir(parents=True)
+    (downloads / source_display / "Alias One").mkdir(parents=True)
+    alias2_dir = downloads / source_display / "Alias Two"
+    alias2_dir.mkdir(parents=True)
+    cbz = alias2_dir / f"{chapter_name}.cbz"
+    _make_cbz(cbz)
+
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+
+    assert result == cbz
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `backend/.venv/bin/pytest backend/tests/test_file_relocator.py::test_find_staging_path_found_in_alias_folder -v`
+Expected: FAIL — `find_staging_path` signature has changed
+
+- [ ] **Step 3: Add `_build_manga_titles` helper and refactor `find_staging_path()`**
+
+Add this helper near the top of `file_relocator.py` (after imports, before `find_staging_path`):
+
+```python
+def _build_manga_titles(comic: Comic) -> list[str]:
+    """Build ordered list of folder names to search: primary title + aliases."""
+    titles = [comic.title]
+    for alias in comic.aliases:
+        titles.append(alias.title)
+    return titles
+```
+
+Replace `find_staging_path()` (lines 144-221) with:
+
+```python
+def find_staging_path(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    chapter_name: str,
+    source_display_name: str,
+) -> Path | None:
+    """Find a chapter's staging file by searching through title and alias folders.
+
+    Derives manga titles from the Comic (primary title + aliases) and chapter
+    number from the ChapterAssignment. Tries each title folder in order and
+    returns the first successful match.
+    """
+    manga_titles = _build_manga_titles(comic)
+    chapter_number = assignment.chapter_number
+
+    if not manga_titles:
+        return None
+
+    for manga_title in manga_titles:
+        if manga_title == "":
+            continue
+        result = _find_staging_path_for_title(
+            chapter_name, manga_title, source_display_name, chapter_number
+        )
+        if result is not None:
+            return result
+
+    return None
+
+
+def _find_staging_path_for_title(
+    chapter_name: str,
+    manga_title: str,
+    source_display_name: str,
+    chapter_number: float,
+) -> Path | None:
+    """Search for a chapter file under a single manga title directory.
+
+    This is the internal search logic that runs for each title in the alias list.
+    """
+    source_dir = Path(settings.SUWAYOMI_DOWNLOAD_PATH) / source_display_name
+    base = _find_manga_subdir(source_dir, manga_title)
+
+    if base is None:
+        download_root = Path(settings.SUWAYOMI_DOWNLOAD_PATH)
+        norm_display = _normalize_source_name(source_display_name)
+        candidates = [
+            d
+            for d in download_root.iterdir()
+            if d.is_dir()
+            and _normalize_source_name(d.name).startswith(norm_display)
+            and _find_manga_subdir(d, manga_title) is not None
+        ]
+        if len(candidates) == 1:
+            logger.warning(
+                "file_relocator: source dir %r not found; using fuzzy match %r for display name %r (title %r)",
+                source_display_name,
+                candidates[0].name,
+                source_display_name,
+                manga_title,
+            )
+            base = _find_manga_subdir(candidates[0], manga_title)
+        elif len(candidates) > 1:
+            logger.warning(
+                "file_relocator: ambiguous source directory for display name %r — "
+                "multiple fuzzy matches: %s (title %r)",
+                source_display_name,
+                [d.name for d in candidates],
+                manga_title,
+            )
+            return None
+
+    if base is None:
+        base = source_dir / manga_title
+
+    # --- 1. Exact CBZ match ---
+    exact = base / f"{chapter_name}.cbz"
+    if exact.exists():
+        return exact
+
+    # --- 2. Exact folder match ---
+    exact_folder = base / chapter_name
+    if exact_folder.is_dir():
+        return exact_folder
+
+    # --- 3. Regex CBZ match ---
+    cbz_matches = _match_by_regex(base, chapter_number, [".cbz"])
+    if len(cbz_matches) == 1:
+        return cbz_matches[0]
+
+    # --- 4. Regex folder match ---
+    folder_matches = _match_by_regex(base, chapter_number, [])
+    if len(folder_matches) == 1:
+        return folder_matches[0]
+
+    # --- 5. Single CBZ fallback ---
+    matches = list(base.glob("*.cbz"))
+    if len(matches) == 1:
+        return matches[0]
+
+    # --- 6. Single folder fallback ---
+    subdirs = [p for p in base.iterdir() if p.is_dir()] if base.is_dir() else []
+    if len(subdirs) == 1:
+        return subdirs[0]
+
+    logger.warning(
+        "file_relocator: ambiguous or missing staging file for chapter %r in %s (title %r)",
+        chapter_name,
+        base,
+        manga_title,
+    )
+    return None
+```
+
+- [ ] **Step 4: Run new alias tests to verify they pass**
+
+Run: `backend/.venv/bin/pytest backend/tests/test_file_relocator.py -k "alias" -v`
+Expected: All 5 alias tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/file_relocator.py backend/tests/test_file_relocator.py
+git commit -m "feat: search alias folders in find_staging_path (#169)"
+```
+
+---
+
+### Task 2: Update `relocate()` and `replace_in_library()` to use Comic/Assignment
+
+**Files:**
+- Modify: `backend/app/services/file_relocator.py:348-481`
+
+- [ ] **Step 1: Update `relocate()` and `_relocate_sync()` signatures**
+
+The `relocate()` function already receives `assignment` and `comic`. Update it to derive `manga_titles` from the comic and pass to `find_staging_path`:
+
+```python
+async def relocate(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    source_display_name: str,
+) -> None:
+    await asyncio.to_thread(
+        _relocate_sync,
+        assignment,
+        comic,
+        db,
+        chapter_name,
+        source_display_name,
+    )
+
+
+def _relocate_sync(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    source_display_name: str,
+) -> None:
+    manga_titles = _build_manga_titles(comic)
+    logger.info(
+        "relocate: starting for comic=%r chapter=%r source=%r",
+        comic.title,
+        chapter_name,
+        source_display_name,
+    )
+    staging = find_staging_path(
+        assignment, comic, chapter_name, source_display_name
+    )
+```
+
+Update the warning and final logs:
+
+```python
+    if staging is None:
+        logger.warning(
+            "relocate: no staging file found for comic=%r chapter=%r source=%r — marking failed",
+            comic.title,
+            chapter_name,
+            source_display_name,
+        )
+        assignment.relocation_status = RelocationStatus.failed
+        return
+
+    # ... (keep existing normalization, comicinfo, cover, pack, place logic)
+
+    logger.info(
+        "relocate: done for comic=%r chapter=%r -> %s", comic.title, chapter_name, dest
+    )
+```
+
+**Key change:** Remove `manga_title` parameter from both signatures. Use `comic.title` for logging and `find_staging_path(assignment, comic, chapter_name, source_display_name)` for the staging lookup.
+
+- [ ] **Step 2: Update `replace_in_library()` and `_replace_in_library_sync()`**
+
+Same pattern — remove `manga_title` parameter, derive from comic:
+
+```python
+async def replace_in_library(
+    old: ChapterAssignment,
+    new: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    source_display_name: str,
+) -> None:
+    await asyncio.to_thread(
+        _replace_in_library_sync,
+        old,
+        new,
+        comic,
+        db,
+        chapter_name,
+        source_display_name,
+    )
+
+
+def _replace_in_library_sync(
+    old: ChapterAssignment,
+    new: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    source_display_name: str,
+) -> None:
+    logger.info(
+        "replace_in_library: starting upgrade for comic=%r chapter=%r source=%r",
+        comic.title,
+        chapter_name,
+        source_display_name,
+    )
+    staging = find_staging_path(
+        new, comic, chapter_name, source_display_name
+    )
+```
+
+Update warning logs similarly using `comic.title`.
+
+- [ ] **Step 3: Run linter**
+
+Run: `backend/.venv/bin/ruff check backend/app/services/file_relocator.py`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/file_relocator.py
+git commit -m "refactor: relocate/replace_in_library derive titles from Comic (#169)"
+```
+
+---
+
+### Task 3: Update `chapter_event_handler.py` — load aliases, simplify calls
+
+**Files:**
+- Modify: `backend/app/workers/chapter_event_handler.py:24-162`
+
+- [ ] **Step 1: Load Comic with aliases eagerly and simplify file_relocator calls**
+
+In `chapter_event_handler.py`, update the Comic load to eagerly fetch aliases:
+
+```python
+        comic = await db.execute(
+            select(Comic)
+            .where(Comic.id == assignment.comic_id)
+            .options(selectinload(Comic.aliases))
+        )
+        comic = comic.scalar_one()
+```
+
+Update `file_relocator.relocate()` call — remove `manga_title` parameter:
+
+```python
+                await file_relocator.relocate(
+                    assignment,
+                    comic,
+                    db,
+                    chapter_name=chapter_name,
+                    source_display_name=source_display_name,
+                )
+```
+
+Update `file_relocator.replace_in_library()` call — remove `manga_title` parameter:
+
+```python
+                    await file_relocator.replace_in_library(
+                        existing_active,
+                        assignment,
+                        comic,
+                        db,
+                        chapter_name=chapter_name,
+                        source_display_name=source_display_name,
+                    )
+```
+
+- [ ] **Step 2: Run existing chapter event handler tests**
+
+Run: `backend/.venv/bin/pytest backend/tests/test_chapter_event_handler.py -v`
+Expected: All tests PASS (tests may need updating to match new signatures)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/workers/chapter_event_handler.py
+git commit -m "feat: chapter_event_handler loads aliases for file_relocator (#169)"
+```
+
+---
+
+### Task 4: Fix `requests.py` reprocess — undefined `manga_title` + aliases
+
+**Files:**
+- Modify: `backend/app/api/requests.py:665-900`
+
+- [ ] **Step 1: Load Comic with aliases and update all file_relocator calls**
+
+In `reprocess_chapters()`, update the Comic load to include aliases:
+
+```python
+        comic_result = await db.execute(
+            select(Comic)
+            .where(Comic.id == comic_id)
+            .options(selectinload(Comic.aliases))
+        )
+        comic = comic_result.scalar_one_or_none()
+```
+
+Remove all `manga_title` variable references. Update `find_staging_path` calls (lines 748, 831):
+
+```python
+                staging = file_relocator.find_staging_path(
+                    assignment, comic, chapter_name, source_display_name
+                )
+```
+
+Update `relocate()` calls (lines 768, 849) — remove `manga_title` parameter:
+
+```python
+                    await file_relocator.relocate(
+                        assignment,
+                        comic,
+                        db,
+                        chapter_name=chapter_name,
+                        source_display_name=source_display_name,
+                    )
+```
+
+Update `replace_in_library()` calls (lines 777, 858) — remove `manga_title` parameter:
+
+```python
+                    await file_relocator.replace_in_library(
+                        existing_active,
+                        assignment,
+                        comic,
+                        db,
+                        chapter_name=chapter_name,
+                        source_display_name=source_display_name,
+                    )
+```
+
+- [ ] **Step 2: Run linter**
+
+Run: `backend/.venv/bin/ruff check backend/app/api/requests.py`
+Expected: No new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/api/requests.py
+git commit -m "fix: resolve undefined manga_title in reprocess, use Comic object (#169)"
+```
+
+---
+
+### Task 5: Update existing tests to match new signatures
+
+**Files:**
+- Modify: `backend/tests/test_file_relocator.py`
+
+- [ ] **Step 1: Update `_make_comic()` helper to support aliases**
+
+Update the helper:
+
+```python
+def _make_comic(title="My Comic", library_title="My Comic Library", cover_path=None, aliases=None):
+    return SimpleNamespace(
+        title=title, library_title=library_title, cover_path=cover_path, aliases=aliases or []
+    )
+```
+
+- [ ] **Step 2: Update all `find_staging_path()` test calls**
+
+Replace all calls from:
+```python
+file_relocator.find_staging_path(chapter_name, manga_title, source_display, chapter_number)
+```
+To:
+```python
+file_relocator.find_staging_path(assignment, comic, chapter_name, source_display)
+```
+
+Each test must create a matching `comic` and `assignment`:
+```python
+    comic = _make_comic(title=manga_title)
+    assignment = _make_assignment(chapter_number=1.0)
+    result = file_relocator.find_staging_path(
+        assignment, comic, chapter_name, source_display
+    )
+```
+
+Apply to all affected tests:
+- `test_find_staging_path_returns_folder`
+- `test_find_staging_path_source_dir_space_stripped`
+- `test_find_staging_path_source_dir_with_suffix`
+- `test_find_staging_path_source_dir_case_mismatch`
+- `test_find_staging_path_source_dir_ambiguous_returns_none`
+- `test_find_staging_path_exact_match_skips_fallback`
+- `test_find_staging_path_sanitized_*`
+- `test_find_staging_path_empty_manga_title_returns_none`
+- All `TestFindStagingPathRegex` methods
+
+For `test_find_staging_path_empty_manga_title_returns_none`, use `_make_comic(title="")` — the function should return `None` because the only title is empty.
+
+- [ ] **Step 3: Update `relocate()` and `replace_in_library()` test calls**
+
+Remove `manga_title` parameter from all calls. For example:
+
+```python
+# Before:
+await file_relocator.relocate(
+    assignment, comic, None, chapter_name, manga_title, source_display
+)
+
+# After:
+await file_relocator.relocate(
+    assignment, comic, None, chapter_name, source_display
+)
+```
+
+- [ ] **Step 4: Run all file relocator tests**
+
+Run: `backend/.venv/bin/pytest backend/tests/test_file_relocator.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `backend/.venv/bin/pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/tests/test_file_relocator.py
+git commit -m "test: update tests for Comic/Assignment-based API (#169)"
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run linter on all modified files**
+
+Run: `backend/.venv/bin/ruff check backend/app/services/file_relocator.py backend/app/workers/chapter_event_handler.py backend/app/api/requests.py`
+Expected: No new errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `backend/.venv/bin/pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run integration tests (if .env.test is configured)**
+
+Run: `backend/.venv/bin/pytest -m integration -v`
+Expected: Integration tests PASS (or skip if no Suwayomi configured)
+
+- [ ] **Step 4: Stage and commit any remaining changes**
+
+```bash
+git add -A
+git status
+git commit -m "chore: final adjustments for alias folder search (#169)"
+```
+(Only if there are remaining changes)
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage:** All spec requirements addressed — `find_staging_path` accepts Comic+Assignment, derives titles from Comic (primary + aliases), caller updates for both `chapter_event_handler` and `requests.py`, test updates, alias tests.
+- [x] **Placeholder scan:** No TBD, TODO, or vague instructions. All code blocks are complete.
+- [x] **Type consistency:** `find_staging_path(assignment, comic, chapter_name, source_display_name)` used consistently. `relocate()` and `replace_in_library()` both removed `manga_title` parameter.
+- [x] **TDD:** Tests written before implementation in Task 1.
+- [x] **Frequent commits:** 5 commits mapped to logical boundaries.

--- a/docs/superpowers/specs/2026-06-23-alias-folders-file-relocator-design.md
+++ b/docs/superpowers/specs/2026-06-23-alias-folders-file-relocator-design.md
@@ -1,0 +1,151 @@
+# Design: Alias Folder Search in File Relocator
+
+**Date:** 2026-06-23
+**Issue:** [#169](https://github.com/Svagtlys/Otaki/issues/169)
+**PR:** [#178](https://github.com/Svagtlys/Otaki/pull/178)
+**Branch:** `fix/alias-folders-file-relocator`
+
+## Problem
+
+`file_relocator.find_staging_path()` only searches the primary comic title folder for chapter files in Suwayomi's staging directory. Some comics download to folders named after their aliases (not the primary title). When this happens, relocation fails because the staging file cannot be found.
+
+Additionally, `requests.py` `reprocess_chapters()` references an undefined `manga_title` variable at six call sites, causing the reprocess endpoint to fail.
+
+## Solution
+
+Refactor `find_staging_path()` to accept `Comic` and `ChapterAssignment` domain objects instead of individual primitive parameters. The function derives manga titles (primary title + aliases) from the `Comic` object and chapter number from the `ChapterAssignment`. This makes the API resilient to future model changes — if new title-related fields are added to `Comic`, the function automatically benefits without signature changes.
+
+`relocate()` and `replace_in_library()` similarly derive manga titles from their `Comic` parameter, removing the need for callers to construct title lists manually.
+
+## Architecture
+
+### Modified Function Signatures
+
+```python
+# Before
+def find_staging_path(
+    chapter_name: str,
+    manga_title: str,
+    source_display_name: str,
+    chapter_number: float,
+) -> Path | None:
+
+async def relocate(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    manga_title: str,
+    source_display_name: str,
+) -> None:
+
+# After
+def find_staging_path(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    chapter_name: str,
+    source_display_name: str,
+) -> Path | None:
+
+async def relocate(
+    assignment: ChapterAssignment,
+    comic: Comic,
+    db: AsyncSession,
+    chapter_name: str,
+    source_display_name: str,
+) -> None:
+```
+
+### New Helper: `_build_manga_titles(comic: Comic) -> list[str]`
+
+Extracts the ordered list of folder names from a `Comic` object:
+
+```python
+def _build_manga_titles(comic: Comic) -> list[str]:
+    titles = [comic.title]
+    for alias in comic.aliases:
+        titles.append(alias.title)
+    return titles
+```
+
+### Internal Logic Change
+
+`find_staging_path()` calls `_build_manga_titles(comic)` and loops through each title. The existing per-title search logic is extracted to `_find_staging_path_for_title()` (the original search pipeline, unchanged):
+
+1. Exact source directory match → `_find_manga_subdir()`
+2. Fuzzy source directory fallback (if exact fails)
+3. Within the manga subdirectory: exact CBZ → exact folder → regex CBZ → regex folder → single CBZ → single folder
+
+### Callers
+
+| Caller | Location | Change |
+|--------|----------|--------|
+| `_relocate_sync` | `file_relocator.py:367` | Derives titles from `comic` internally |
+| `_replace_in_library_sync` | `file_relocator.py:434` | Derives titles from `comic` internally |
+| `relocate()` | `file_relocator.py:348` | Removed `manga_title` parameter |
+| `replace_in_library()` | `file_relocator.py:413` | Removed `manga_title` parameter |
+| `handle()` | `chapter_event_handler.py:24` | Loads Comic with `selectinload(Comic.aliases)`, removes `manga_title` param |
+| `reprocess_chapters()` | `requests.py:665` | Loads Comic with `selectinload(Comic.aliases)`, removes `manga_title` variable |
+
+### requests.py manga_title Fix
+
+The undefined `manga_title` variable is eliminated entirely. `reprocess_chapters()` loads the `Comic` with `selectinload(Comic.aliases)` and passes it to `file_relocator` functions, which derive titles internally.
+
+## Data Flow
+
+```
+chapter_event_handler.handle() / requests.py reprocess_chapters()
+  │
+  ├─ Load Comic with selectinload(Comic.aliases)
+  │
+  ▼
+find_staging_path(assignment, comic, chapter_name, source_display_name)
+  │
+  ├─ _build_manga_titles(comic) → [comic.title, *alias_titles]
+  │
+  ├─ For each title in titles:
+  │    ├─ Try exact source dir → _find_manga_subdir(source_dir, title)
+  │    ├─ If None, try fuzzy source fallback
+  │    ├─ Within manga subdir: exact CBZ, exact folder, regex CBZ, regex folder, single fallbacks
+  │    └─ If chapter file found → return Path immediately
+  │
+  └─ No match after all titles → return None (relocation fails)
+```
+
+## Error Handling
+
+- **Multiple titles match in different directories:** First title wins (primary > aliases).
+- **Ambiguous matches within a single directory:** Existing behavior preserved — returns `None` and logs warning.
+- **Logging:** Warnings now include the title being searched.
+
+## Testing Strategy
+
+### Unit Tests for `find_staging_path()`
+- Chapter found in primary title folder (existing behavior preserved)
+- Chapter found in alias folder (new behavior)
+- Chapter found in second alias folder (skipping first)
+- Chapter not found in any folder (returns `None`)
+- Comic with no aliases searches only primary title
+
+### Tests for callers
+- `chapter_event_handler` loads Comic with aliases
+- `requests.py` reprocess loads Comic with aliases
+
+### Existing test updates
+- `_make_comic()` helper gains `aliases` parameter
+- All existing tests updated to pass Comic/Assignment objects
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `backend/app/services/file_relocator.py` | New helper, refactored `find_staging_path`, simplified `relocate`/`replace_in_library` signatures |
+| `backend/app/workers/chapter_event_handler.py` | Load Comic with aliases, remove `manga_title` param |
+| `backend/app/api/requests.py` | Load Comic with aliases, remove undefined `manga_title` |
+| `backend/tests/test_file_relocator.py` | Update helpers, update existing tests, add alias tests |
+
+## Out of Scope
+
+- Alias searching for `library_title` (library path resolution uses `comic.library_title` which is the canonical name)
+- Alias searching in Suwayomi download queue (Suwayomi uses its own manga title)
+- Performance optimization (alias count is expected to be small, < 10)


### PR DESCRIPTION
Closes #169

## Description
Some comics may be downloaded to a folder named with an alias of the comic rather than the chosen comic name. file_relocator needs to check for chapters in each location: selected name, then aliases.

## Implementation
- Refactor `find_staging_path()` to accept `Comic` and `ChapterAssignment` domain objects instead of primitives
- Add alias folder search: primary title folder checked first, then alias folders
- Update `chapter_event_handler` and `requests.py` reprocess endpoint to use new API
- Remove `chapter_name` parameter from `file_relocator` (pulled from `ChapterAssignment`)
- Add comprehensive tests for alias folder search and priority

## References
- Design doc: `docs/superpowers/specs/2026-06-23-alias-folders-file-relocator-design.md`
- Implementation plan: `docs/superpowers/plans/2026-06-23-alias-folders-file-relocator.md`

## Checklist
- [x] Implementation complete
- [x] Tests passing
- [x] Documentation updated (if applicable)