### PR TITLE
hotfix: mark v1.2.0 features as released in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A comic/manga request manager built on top of [Suwayomi-Server](https://github.c
 |---|---|---|
 | **1.0** | MVP — download pipeline, source upgrades, basic auth | Released |
 | **1.1** | Metadata — `ComicInfo.xml`, covers, multi-alias, cadence inference, per-comic schedules | Released |
-| **1.2** | Scale — local source overrides, pagination, library import | Planned |
+| **1.2** | Scale — local source overrides, pagination, library import | Released |
 | **1.3** | Quality — watermark/banner detection, auto-fix, image order checking | Planned |
 | **1.4** | Auth — roles, SSO, user management | Planned |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,11 +57,11 @@ Make the library usable in a comic reader without manual cleanup. Also lays the 
 
 Stronger cross-source coverage and library management at scale.
 
-- [ ] Comic-local source priority overrides (e.g. source B is better than source A for one specific series)
-- [ ] Pagination for Library and Comic detail views
-- [ ] Search and filter within tracked library (by source, status)
+- [x] Comic-local source priority overrides (e.g. source B is better than source A for one specific series)
+- [x] Pagination for Library and Comic detail views
+- [x] Search and filter within tracked library (by source, status)
 - [ ] Import existing library (scan pre-existing CBZs into Otaki without re-downloading)
-- [ ] Export / backup of Otaki DB, covers, and watermarks
+- [x] Export / backup of Otaki DB, covers, and watermarks
 
 ---
 


### PR DESCRIPTION
Update README and ROADMAP to reflect v1.2.0 release status.

**Merge into:** main, release/1.2, develop (3-way hotfix merge, no new tag needed)